### PR TITLE
Footnotes syntax

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -114,6 +114,7 @@ HtmlHiLink mkdLineContinue  Comment
 HtmlHiLink mkdListItem      Identifier
 HtmlHiLink mkdRule          Identifier
 HtmlHiLink mkdLineBreak     Todo
+HtmlHiLink mkdFootnotes     htmlLink
 HtmlHiLink mkdLink          htmlLink
 HtmlHiLink mkdURL           htmlString
 HtmlHiLink mkdInlineURL     htmlLink


### PR DESCRIPTION
To support footnotes syntax

   [^1] 

mkdFootnotes is added in mkd.vim and to remove mismatch normal Link, mkdLink is revised not to include footnotes syntax
