### PR TITLE
Added a rule that covers "Github Flavored Markdown" (GFM) code blocks

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -70,6 +70,7 @@ syn match  mkdCode      /^\s*\n\(\(\s\{4,}[^ ]\|\t\+[^\t]\).*\n\)\+/
 syn match  mkdLineBreak /  \+$/
 syn region mkdCode      start=/\\\@<!`/                   end=/\\\@<!`/
 syn region mkdCode      start=/\s*``[^`]*/          end=/[^`]*``\s*/
+syn region mkdCode      start=/^```\w*\s*$/          end=/^```\s*$/
 syn region mkdBlockquote start=/^\s*>/              end=/$/                 contains=mkdLineBreak,mkdLineContinue,@Spell
 syn region mkdCode      start="<pre[^>]*>"         end="</pre>"
 syn region mkdCode      start="<code[^>]*>"        end="</code>"


### PR DESCRIPTION
GFM takes three back ticks to start a code block. It can be followed with a word specifying the language. It then ends with three back ticks.
http://github.github.com/github-flavored-markdown/
