### PR TITLE
Allow whitespace between three backticks and language name in GFM code

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -70,7 +70,7 @@ syn match  mkdCode      /^\s*\n\(\(\s\{4,}[^ ]\|\t\+[^\t]\).*\n\)\+/
 syn match  mkdLineBreak /  \+$/
 syn region mkdCode      start=/\\\@<!`/                   end=/\\\@<!`/
 syn region mkdCode      start=/\s*``[^`]*/          end=/[^`]*``\s*/
-syn region mkdCode      start=/^```\w*\s*$/          end=/^```\s*$/
+syn region mkdCode      start=/^```\s*\w*\s*$/          end=/^```\s*$/
 syn region mkdBlockquote start=/^\s*>/              end=/$/                 contains=mkdLineBreak,mkdLineContinue,@Spell
 syn region mkdCode      start="<pre[^>]*>"         end="</pre>"
 syn region mkdCode      start="<code[^>]*>"        end="</code>"


### PR DESCRIPTION
Github Flavored Markdown seems to allow whitespace between the three backticks to start a code block and the name of the language the code is in.

Some guides on using [Markdown and GFM code blocks](http://octopress.org/docs/blogging/code/) seem to encourage a space between the backticks and language name as if it was standard.

This can be supported in the syntax file with a simple addition of `\s*` before `\w*`. Without this the presence of whitespace between the backticks and the language name screws up color highlighting for subsequent non-code sections of the document.
