### PR TITLE
mkdCode start (syntax name) could contain hyphen

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -66,7 +66,7 @@ syn match  mkdLineBreak    /  \+$/
 syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLineBreak,mkdLineContinue,@Spell
 syn region mkdCode         start=/\(\([^\\]\|^\)\\\)\@<!`/ end=/\(\([^\\]\|^\)\\\)\@<!`/
 syn region mkdCode         start=/\s*``[^`]*/              end=/[^`]*``\s*/
-syn region mkdCode         start=/^```\s*\w*\s*$/          end=/^```\s*$/
+syn region mkdCode         start=/^```\s*[0-9A-Za-z_-]*\s*$/          end=/^```\s*$/
 syn region mkdCode         start="<pre[^>]*>"              end="</pre>"
 syn region mkdCode         start="<code[^>]*>"             end="</code>"
 syn region mkdFootnote     start="\[^"                     end="\]"


### PR DESCRIPTION
E.g.:

``` no-highlight
bla-bla
```
