### PR TITLE
Fix unletting non-existant b:current_syntax.

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -15,7 +15,10 @@ if version < 600
   so <sfile>:p:h/html.vim
 else
   runtime! syntax/html.vim
-  unlet b:current_syntax
+
+  if exists('b:current_syntax')
+    unlet b:current_syntax
+  endif
 endif
 
 if version < 600


### PR DESCRIPTION
Fixed an issue where `unlet b:current_syntax` occurs when recovering from a Session and b:current_syntax has not been set yet.
