### PR TITLE
Added setlocal formatoptions-=c to disable automatically inserting bullets when auto-wrapping; Support Auto-indentation in list

### DIFF
--- a/indent/mkd.vim
+++ b/indent/mkd.vim
@@ -1,0 +1,46 @@
+if exists("b:did_indent") | finish | endif
+let b:did_indent = 1
+
+setlocal indentexpr=GetMkdIndent()
+setlocal nolisp
+setlocal nosmartindent
+setlocal autoindent
+
+" Only define the function once
+if exists("*GetMkdIndent") | finish | endif
+
+function! s:is_li_start(line)
+    return a:line =~ '^\s*[\*+-]'
+endfunction
+
+function! s:is_blank_line(line)
+    return a:line =~ '^$'
+endfunction
+
+function! s:prevnonblank(lnum)
+    let i = a:lnum
+    while i > 1 && s:is_blank_line(getline(i))
+        let i -= 1
+    endwhile
+    return i
+endfunction
+
+function GetMkdIndent()
+    let list_ind = 4
+    " Find a non-blank line above the current line.
+    let lnum = prevnonblank(v:lnum - 1)
+    " At the start of the file use zero indent.
+    if lnum == 0 | return 0 | endif
+    let ind = indent(lnum)
+    let line = getline(lnum)    " Last line
+    let cline = getline(v:lnum) " Current line
+    if s:is_li_start(cline) 
+        " Current line is the first line of a list item, do not change indent
+        return indent(v:lnum)
+    elseif s:is_li_start(line)
+        " Last line is the first line of a list item, increase indent
+        return ind + list_ind
+    else
+        return ind
+    endif
+endfunction

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -119,6 +119,8 @@ HtmlHiLink mkdDelimiter     Delimiter
 
 " Automatically insert bullets
 setlocal formatoptions+=r
+" Do not automatically insert bullets when auto-wrapping with text-width
+setlocal formatoptions-=c
 " Accept various markers as bullets
 setlocal comments=b:*,b:+,b:-
 


### PR DESCRIPTION
Usually I have "set textwidth=80" for MarkDown files. It is annoying that vim keeps adding bullets on auto-wrapping and I believe this is not an expected behavior for most people. This change makes sure the behavior is prevented. 
