### PR TITLE
Add Toc commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ The following work on normal and visual modes:
 - `]c`: go to Current header.
 - `]u`: go to parent header (Up).
 
+## Commands
+
+The following commands currently only work for atx style headers (`#`). Pull request are welcome to extend them to Setext style headers (`===`).
+
+- `:Toc`: create a quickfix vertical window navigable table of contents with the headers.
+
+    Hit `<Enter>` on a line to jump to the corresponding line of the markdown file.
+
+- `:Toch`: Same as `:Toc` but in an horizontal window.
+- `:Toct`: Same as `:Toc` but in a new tab.
+- `:Tocv`: Same as `:Toc` for symmetry with `:Toch` and `Tocv`.
+
 ## Credits
 
 The main contributors of vim-markdown are:

--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -294,6 +294,39 @@ function! b:Markdown_MoveToPreviousSiblingHeader()
     endif
 endfunction
 
+function! b:Markdown_Toc(...)
+    if a:0 > 0
+        let l:window_type = a:1
+    else
+        let l:window_type = 'vertical'
+    endif
+    silent vimgrep '^#' %
+    if l:window_type ==# 'horizontal'
+        copen
+    elseif l:window_type ==# 'vertical'
+        vertical copen
+        let &winwidth=(&columns/2)
+    elseif l:window_type ==# 'tab'
+        tab copen
+    else
+        copen
+    endif
+    set modifiable
+    %s/\v^([^|]*\|){2,2} #//
+    for i in range(1, line('$'))
+        let l:line = getline(i)
+        let l:header =  matchstr(l:line, '^#*')
+        let l:length = len(l:header)
+        let l:line = substitute(l:line, '\v^#*[ ]*', '', '')
+        let l:line = substitute(l:line, '\v[ ]*#*$', '', '')
+        let l:line = repeat(' ', (2 * l:length)) . l:line
+        call setline(i, l:line)
+    endfor
+    set nomodified
+    set nomodifiable
+    normal! gg
+endfunction
+
 " Wrapper to do move commands in visual mode.
 "
 function! s:VisMove(f)
@@ -316,3 +349,8 @@ call <sid>MapNormVis('[]', 'b:Markdown_MoveToPreviousSiblingHeader')
 call <sid>MapNormVis(']u', 'b:Markdown_MoveToParentHeader')
 " Menmonic: Current
 call <sid>MapNormVis(']c', 'b:Markdown_MoveToCurHeader')
+
+command! -buffer Toc call b:Markdown_Toc()
+command! -buffer Toch call b:Markdown_Toc('horizontal')
+command! -buffer Tocv call b:Markdown_Toc('vertical')
+command! -buffer Toct call b:Markdown_Toc('tab')

--- a/test/multiple_headers.md
+++ b/test/multiple_headers.md
@@ -1,0 +1,27 @@
+This file is used for tests which require there to be multiple headers in different relative positions to each other.
+
+Each header should have an unique text that identifies it.
+
+# h1 space
+
+#h1 nospace
+
+# h1 trailing hash #
+
+## h2 space
+
+##h2 nospace
+
+## h2 trailing hash ##
+
+### h3 space
+
+###h3 nospace
+
+### h3 trailing hash ###
+
+# h1 before h2
+
+## h2 between h1s
+
+# h1 after h2


### PR DESCRIPTION
Create a quickfix vertical window with the headers indented according to level.

Fundamental to navigate and understand the structure of large markdown files.

Test with `tests/multiple_headers.md`.

GIF screenshot:

![out](https://cloud.githubusercontent.com/assets/1429315/2559732/b9cfa208-b789-11e3-933a-40106c3559ac.gif)

The following plugin does something similar but I'm not sure if it supports quickfix navigation: https://github.com/matthias-guenther/tocdown/issues/5
