### PR TITLE
Add preferred style guide to CONTRIBUTING.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ There are many flavors of markdown, each one with an unique feature set. This pl
 
     Next, if there are many more than one Jekyll feature options, create a `g:vim_markdown_jekyll` option that turns them all on at once.
 
+# Style
+
+When choosing between multiple valid Markdown syntaxes, the default behavior must be that specified at: <http://www.cirosantilli.com/markdown-styleguide>
+
+If you wish to have a behavior that differs from that style guide, add an option to turn it on or off, and leave it off by default.
+
 # Tests
 
 All new features must have tests. We don't require unit tests: tests that require users to open markdown code in Vim and check things manually are accepted, but you should point clearly to where the tests are.


### PR DESCRIPTION
Sometimes there are multiple possible behaviors that are all valid markdown. E.g.: https://github.com/plasticboy/vim-markdown/pull/70#issuecomment-39181974

We should therefore fix one preferred style.

With all modesty, the best styleguide I could find so far was the one I wrote.

In particular:
- it is compatible with the current behavior of Vim markdown
- one of its design goals is to be easy to implement in text editors: http://www.cirosantilli.com/markdown-styleguide/#design-goals
- I control it, and I will give high priority to suggestions coming from Vim Markdown collaborators
- it is [used by GitLab](https://github.com/gitlabhq/gitlabhq/blob/master/CONTRIBUTING.md#style-guides), which has a measly 13k stars =)

If anyone finds a better option, or wishes to modify one of its points, I'd love to hear it.
