### PR TITLE
Add support for setext headers to the TOC command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ The following work on normal and visual modes:
 
 ## Commands
 
-The following commands currently only work for atx style headers (`#`). Pull request are welcome to extend them to Setext style headers (`===`).
-
 - `:Toc`: create a quickfix vertical window navigable table of contents with the headers.
 
     Hit `<Enter>` on a line to jump to the corresponding line of the markdown file.

--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -300,7 +300,14 @@ function! s:Markdown_Toc(...)
     else
         let l:window_type = 'vertical'
     endif
-    silent vimgrep '^#' %
+
+    try
+        silent vimgrep /\(^\S.*\(\n[=-]\+\)\@=\|^#\+\)/ %
+    catch /E480/
+	echom "Toc: No headers."
+        return
+    endtry
+
     if l:window_type ==# 'horizontal'
         copen
     elseif l:window_type ==# 'vertical'
@@ -314,13 +321,22 @@ function! s:Markdown_Toc(...)
     set modifiable
     %s/\v^([^|]*\|){2,2} #//
     for i in range(1, line('$'))
-        let l:line = getline(i)
-        let l:header =  matchstr(l:line, '^#*')
-        let l:length = len(l:header)
-        let l:line = substitute(l:line, '\v^#*[ ]*', '', '')
-        let l:line = substitute(l:line, '\v[ ]*#*$', '', '')
-        let l:line = repeat(' ', (2 * l:length)) . l:line
-        call setline(i, l:line)
+        " this is the quickfix data for the current item
+        let d = getqflist()[i-1]
+        " atx headers
+        if match(d.text, "^#") > -1
+            let l:level = len(matchstr(d.text, '#*', 'g'))-1
+            let d.text = d.text[l:level+2:]
+            " setex headers
+        else
+            let l:next_line = getbufline(bufname(d.bufnr), d.lnum+1)
+            if match(l:next_line, "=") > -1
+                let l:level = 0
+            elseif match(l:next_line, "-") > -1
+                let l:level = 1
+            endif
+        endif
+        call setline(i, repeat('  ', l:level). d.text)
     endfor
     set nomodified
     set nomodifiable


### PR DESCRIPTION
I took the base of your TOC function for vim-pandoc/vim-pantondoc, adding setext headers support. I thought it would be nice if I shared that back (the full implementation is here: https://github.com/vim-pandoc/vim-pantondoc/blob/master/autoload/pantondoc/toc.vim, you'll see there are some additional differences). Feel free to clean it up.
