### PR TITLE
Don't allow spaces before headers in nav mappings.

### DIFF
--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -47,12 +47,12 @@
 
 " For each level, contains the regexp that matches at that level only.
 let s:levelRegexpDict = {
-    \ 1: '\v^(\s*#[^#]|.+\n\=+$)',
-    \ 2: '\v^(\s*##[^#]|.+\n-+$)',
-    \ 3: '\v^\s*###[^#]',
-    \ 4: '\v^\s*####[^#]',
-    \ 5: '\v^\s*#####[^#]',
-    \ 6: '\v^\s*######[^#]'
+    \ 1: '\v^(#[^#]|.+\n\=+$)',
+    \ 2: '\v^(##[^#]|.+\n-+$)',
+    \ 3: '\v^###[^#]',
+    \ 4: '\v^####[^#]',
+    \ 5: '\v^#####[^#]',
+    \ 6: '\v^######[^#]'
 \ }
 
 " Maches any header level of any type.
@@ -60,7 +60,7 @@ let s:levelRegexpDict = {
 " This could be deduced from `s:levelRegexpDict`, but it is more
 " efficient to have a single regexp for this.
 "
-let s:headersRegexp = '\v^(\s*#|.+\n(\=+|-+)$)'
+let s:headersRegexp = '\v^(#|.+\n(\=+|-+)$)'
 
 " Returns the line number of the first header before `line`, called the
 " current header.


### PR DESCRIPTION
It breaks too often when you have code blocks with comments that start with `#`, and no one uses spaces before headers as in:

```
# Bash tutorial

    # comment in code
    code

## Introduction
```
