### PR TITLE
Global settings override cause conflicts with vim configuration and/or other plugins

### DIFF
--- a/after/ftplugin/mkd.vim
+++ b/after/ftplugin/mkd.vim
@@ -51,6 +51,4 @@ if !exists("g:vim_markdown_folding_disabled")
   " see ':help fold-options' for more
   setlocal foldenable
   setlocal foldcolumn=0
-  set foldmethod=expr
-  set foldopen-=search
 endif


### PR DESCRIPTION
Hello,

There is a configuration part marked as "optional", it contains some commands that override global vim settings. 

For example, I like having `foldmethod = marker`, but after I open any markdown file whole vim is set to `foldmethod = expr` instead.

I removed those global overrides as they are the most painful for me, however I suggest to consider cleaning up the whole "optional" section, maybe make a documentation note instead.
