### PR TITLE
Enable line breaks at word boundaries

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -123,6 +123,8 @@ setlocal formatoptions+=r
 setlocal formatoptions-=c
 " Accept various markers as bullets
 setlocal comments=b:*,b:+,b:-
+" Linebreak at word boundaries
+setlocal linebreak
 
 let b:current_syntax = "mkd"
 


### PR DESCRIPTION
Simple fix, but means that words are wrapped at word boundaries, rather than character boundaries
