### PR TITLE
Changing Vundle "Bundle" references to "Plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Syntax highlighting, matching rules and mappings for [the original Markdown](htt
 
 If you use [Vundle](https://github.com/gmarik/vundle), add the following line to your `~/.vimrc`:
 
-    Bundle 'plasticboy/vim-markdown'
+    Plugin 'plasticboy/vim-markdown'
 
 And then run inside Vim:
 
     :so ~/.vimrc
-    :BundleInstall
+    :PluginInstall
 
 If you use [Pathogen](https://github.com/tpope/vim-pathogen), do this:
 


### PR DESCRIPTION
Vundle is changing their interface from `Bundle*` to `Plugin*`.
See https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396 for more information on this.
