### PR TITLE
Use location for :Toc list instead of quickfix.

### DIFF
--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -302,21 +302,21 @@ function! s:Markdown_Toc(...)
     endif
 
     try
-        silent vimgrep /\(^\S.*\(\n[=-]\+\n\)\@=\|^#\+\)/ %
+        silent lvimgrep /\(^\S.*\(\n[=-]\+\n\)\@=\|^#\+\)/ %
     catch /E480/
         echom "Toc: No headers."
         return
     endtry
 
     if l:window_type ==# 'horizontal'
-        copen
+        lopen
     elseif l:window_type ==# 'vertical'
-        vertical copen
+        vertical lopen
         let &winwidth=(&columns/2)
     elseif l:window_type ==# 'tab'
-        tab copen
+        tab lopen
     else
-        copen
+        lopen
     endif
     set modifiable
     %s/\v^([^|]*\|){2,2} #//


### PR DESCRIPTION
It is the proper place to put it as there can be one per window.

Copied from: https://github.com/vim-pandoc/vim-pandoc/commit/40f7c04be1f44905d01ba8db911a12a2ed26f4fd
