### PR TITLE
Highlight angle braced hyperlinks.

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -5,8 +5,6 @@
 " Version:	9
 " Last Change:  2009 May 18 
 " Remark:	Uses HTML syntax file
-" Remark:	I don't do anything with angle brackets (<>) because that would too easily
-"		easily conflict with HTML syntax
 " TODO: 	Handle stuff contained within stuff (e.g. headings within blockquotes)
 
 
@@ -51,12 +49,16 @@ syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"
 syn region mkdID matchgroup=mkdDelimiter        start="\["    end="\]" contained oneline
 syn region mkdURL matchgroup=mkdDelimiter       start="("     end=")"  contained oneline
 syn region mkdLink matchgroup=mkdDelimiter      start="\\\@<!\[" end="\]\ze\s*[[(]" contains=@Spell nextgroup=mkdURL,mkdID skipwhite oneline
+
+" Autolink without angle brackets.
 " mkd  inline links:           protocol   optional  user:pass@       sub/domain                 .com, .co.uk, etc      optional port   path/querystring/hash fragment
 "                            ------------ _____________________ --------------------------- ________________________ ----------------- __
 syntax match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
 
+" Autolink with angle brackets.
+syn region mkdInlineURL matchgroup=mkdDelimiter start="\\\@<!<\(\(coap\|doi\|javascript\|aaa\|aaas\|about\|acap\|cap\|cid\|crid\|data\|dav\|dict\|dns\|file\|ftp\|geo\|go\|gopher\|h323\|http\|https\|iax\|icap\|im\|imap\|info\|ipp\|iris\|iris.beep\|iris.xpc\|iris.xpcs\|iris.lwz\|ldap\|mailto\|mid\|msrp\|msrps\|mtqp\|mupdate\|news\|nfs\|ni\|nih\|nntp\|opaquelocktoken\|pop\|pres\|rtsp\|service\|session\|shttp\|sieve\|sip\|sips\|sms\|snmp,soap.beep\|soap.beeps\|tag\|tel\|telnet\|tftp\|thismessage\|tn3270\|tip\|tv\|urn\|vemmi\|ws\|wss\|xcon\|xcon-userid\|xmlrpc.beep\|xmlrpc.beeps\|xmpp\|z39.50r\|z39.50s\|adiumxtra\|afp\|afs\|aim\|apt,attachment\|aw\|beshare\|bitcoin\|bolo\|callto\|chrome,chrome-extension\|com-eventbrite-attendee\|content\|cvs,dlna-playsingle\|dlna-playcontainer\|dtn\|dvb\|ed2k\|facetime\|feed\|finger\|fish\|gg\|git\|gizmoproject\|gtalk\|hcp\|icon\|ipn\|irc\|irc6\|ircs\|itms\|jar\|jms\|keyparc\|lastfm\|ldaps\|magnet\|maps\|market,message\|mms\|ms-help\|msnim\|mumble\|mvn\|notes\|oid\|palm\|paparazzi\|platform\|proxy\|psyc\|query\|res\|resource\|rmi\|rsync\|rtmp\|secondlife\|sftp\|sgn\|skype\|smb\|soldat\|spotify\|ssh\|steam\|svn\|teamspeak\|things\|udp\|unreal\|ut2004\|ventrilo\|view-source\|webcal\|wtai\|wyciwyg\|xfire\|xri\|ymsgr\):\/\/[^> ]*>\)\@=" end=">"
+
 " Link definitions: [id]: URL (Optional Title)
-" TODO handle automatic links without colliding with htmlTag (<URL>)
 syn region mkdLinkDef matchgroup=mkdDelimiter   start="^ \{,3}\zs\[" end="]:" oneline nextgroup=mkdLinkDefTarget skipwhite
 syn region mkdLinkDefTarget start="<\?\zs\S" excludenl end="\ze[>[:space:]\n]"   contained nextgroup=mkdLinkTitle,mkdLinkDef skipwhite skipnl oneline
 syn region mkdLinkTitle matchgroup=mkdDelimiter start=+"+     end=+"+  contained
@@ -99,13 +101,13 @@ if get(g:, 'vim_markdown_math', 0)
   syn region mkdMath matchgroup=mkdDelimiter start="\\\@<!\$\$" end="\$\$"
 endif
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdMath,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
-
 " YAML frontmatter
 if get(g:, 'vim_markdown_frontmatter', 0)
   syn include @yamlTop syntax/yaml.vim
   syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop
 endif
+
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String

--- a/test/syntax.md
+++ b/test/syntax.md
@@ -1,4 +1,4 @@
-Fenced code living in an indented environment is correctly highlighted:
+# Fenced code living in an indented environment is correctly highlighted
 
 1. run this command to do this:
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -31,6 +31,55 @@ Given mkd;
 Execute (multiple links on a line):
   AssertEqual SyntaxOf('c'), ''
 
+# Autolinks
+
+Given mkd;
+a <http://b> c
+
+Execute (autolink):
+  AssertNotEqual SyntaxOf('a'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('<'), 'mkdDelimiter'
+  AssertEqual SyntaxOf('b'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('>'), 'mkdDelimiter'
+  AssertNotEqual SyntaxOf('c'), 'mkdInlineURL'
+
+Given mkd;
+<HtTp://a>
+
+Execute (autolink with scheme case is insensitive):
+  AssertEqual SyntaxOf('a'), 'mkdInlineURL'
+
+Given mkd;
+<notascheme://a>
+
+Execute (autolink without known scheme is not a link):
+  AssertNotEqual SyntaxOf('n'), 'mkdInlineURL'
+
+Given mkd;
+<a>
+
+Execute (autolink without scheme is not a link):
+  AssertNotEqual SyntaxOf('a'), 'mkdInlineURL'
+
+Given mkd;
+< http://a >
+<http://b c>
+<http://d
+e>
+
+Execute (autolink with space is not a link):
+  AssertNotEqual SyntaxOf('a'), 'mkdInlineURL'
+  AssertNotEqual SyntaxOf('b'), 'mkdInlineURL'
+  AssertNotEqual SyntaxOf('c'), 'mkdInlineURL'
+  AssertNotEqual SyntaxOf('d'), 'mkdInlineURL'
+  AssertNotEqual SyntaxOf('e'), 'mkdInlineURL'
+
+Given mkd;
+\<http://a>
+
+Execute (autolinks can be backslash escaped):
+  AssertNotEqual SyntaxOf('<'), 'mkdDelimiter'
+
 # Math
 
 Given mkd;


### PR DESCRIPTION
Fixes #104

Follows specification at: http://jgm.github.io/stmd/spec.html#autolinks . Note that that spec does not allow autolinks without braces, even though many implementations do it.

Also fixes autolinks without angle braces which were not being highlighted on top level, because I had to add them to the toplevel cluster.

Does not conflict with HTML tags because only strings with certain protocols are allowed.
