### PR TITLE
Fix parenthesis () and square brackets [] that were rendered as links when not in link.

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -94,7 +94,7 @@ syn region htmlH6       start="^\s*######"              end="\($\|#\+\)" contain
 syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String

--- a/test/syntax.md
+++ b/test/syntax.md
@@ -15,3 +15,75 @@ def f
   0
 end
 ```
+
+# Links
+
+[a](b "c")
+
+[a]()
+
+[good spell](a)
+
+[badd spell](a)
+
+[a](b "c")
+
+[a]( b
+"c" )
+
+a (`a`) b. Fix: <https://github.com/plasticboy/vim-markdown/issues/113>
+
+Escaped:
+
+\[a](b)
+
+[a\]b](c)
+
+## Known failures
+
+Escape does not work:
+
+[a\](b)
+
+Should not be links because of whitespace:
+
+[a] (b)
+
+[a](a
+b)
+
+[a](a b)
+
+# Reference links
+
+Single links:
+
+[a][b]
+
+[good spell][a]
+
+[badd spell][a]
+
+[a][]
+
+[a] []
+
+[a][b] c [d][e]
+
+Reference link followed by inline link:
+
+[a] [b](c)
+
+## Known failures
+
+Should be shortcut reference links:
+
+[a]
+
+[a] b [c]
+
+Should be a single link:
+
+[a] [b]
+
+[a] b [c](d)

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -9,3 +9,22 @@ Given mkd (italic);
 
 Execute (SyntaxOf(pattern)):
   AssertEqual SyntaxOf('i'), 'htmlItalic'
+
+Given mkd;
+[a](b)
+
+Execute (link with title):
+  AssertEqual SyntaxOf('a'), 'mkdLink'
+  AssertEqual SyntaxOf('b'), 'mkdURL'
+
+Given mkd;
+(a)
+
+Execute (parenthesis not in link):
+  AssertNotEqual SyntaxOf('a'), 'mkdLink'
+
+Given mkd;
+[a](b) c [d](e)
+
+Execute (multiple links on a line):
+  AssertEqual SyntaxOf('c'), ''


### PR DESCRIPTION
Fixes #113 #57 

Taken from: https://github.com/prurigro/vim-markdown-concealed/commit/6567c0a48484ffca161bb34216ad1aacba208ba2
