### PR TITLE
Add LateX $ and $$ math support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Add the following line to your `.vimrc` to disable default key mappings. You can
 let g:vim_markdown_no_default_key_mappings=1
 ```
 
+**Syntax extensions**
+
+The following options control which syntax extensions will be turned on.
+
+LaTeX math: `$ $`, `$$ $$`, escapable as `\$ \$` and `\$\$ \$\$`:
+
+```vim
+let g:vim_markdown_math=1
+```
 ## Mappings
 
 The following work on normal and visual modes:

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -94,7 +94,12 @@ syn region htmlH6       start="^\s*######"              end="\($\|#\+\)" contain
 syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
+if get(g:, 'vim_markdown_math', 0)
+  syn region mkdMath matchgroup=mkdDelimiter start="\\\@<!\$" end="\$"
+  syn region mkdMath matchgroup=mkdDelimiter start="\\\@<!\$\$" end="\$\$"
+endif
+
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdMath,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String
@@ -114,7 +119,7 @@ HtmlHiLink mkdID            Identifier
 HtmlHiLink mkdLinkDef       mkdID
 HtmlHiLink mkdLinkDefTarget mkdURL
 HtmlHiLink mkdLinkTitle     htmlString
-
+HtmlHiLink mkdMath          Statement
 HtmlHiLink mkdDelimiter     Delimiter
 
 " Automatically insert bullets

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -10,6 +10,8 @@ Given mkd (italic);
 Execute (SyntaxOf(pattern)):
   AssertEqual SyntaxOf('i'), 'htmlItalic'
 
+# Links
+
 Given mkd;
 [a](b)
 
@@ -28,3 +30,45 @@ Given mkd;
 
 Execute (multiple links on a line):
   AssertEqual SyntaxOf('c'), ''
+
+# Math
+
+Given mkd;
+a $x$ b
+c $$y$$ d
+\$e\$
+\$\$f\$\$
+
+Execute (math):
+  AssertNotEqual SyntaxOf('x'), 'mkdMath'
+  AssertNotEqual SyntaxOf('y'), 'mkdMath'
+  let g:vim_markdown_math=1
+  syn off | syn on
+  AssertNotEqual SyntaxOf('a'), 'mkdMath'
+  AssertNotEqual SyntaxOf('b'), 'mkdMath'
+  AssertNotEqual SyntaxOf('c'), 'mkdMath'
+  AssertNotEqual SyntaxOf('d'), 'mkdMath'
+  AssertNotEqual SyntaxOf('e'), 'mkdMath'
+  AssertNotEqual SyntaxOf('f'), 'mkdMath'
+  AssertEqual SyntaxOf('x'), 'mkdMath'
+  AssertEqual SyntaxOf('y'), 'mkdMath'
+  let g:vim_markdown_math=0
+  syn off | syn on
+  AssertNotEqual SyntaxOf('x'), 'mkdMath'
+  AssertNotEqual SyntaxOf('y'), 'mkdMath'
+
+Given mkd;
+a
+
+$
+b
+$
+
+c
+
+Execute (multiline math):
+  let g:vim_markdown_math=1
+  syn off | syn on
+  AssertNotEqual SyntaxOf('a'), 'mkdMath'
+  AssertEqual SyntaxOf('b'), 'mkdMath'
+  AssertNotEqual SyntaxOf('c'), 'mkdMath'


### PR DESCRIPTION
Fix: https://github.com/plasticboy/vim-markdown/issues/98

Follow standard LaTeX rules, only for `$`. Reasonable choice since the main target is MathJax which uses those rules.

Not implemented for `\[` and `\]` as those are harder to implement, and less "Markdownish" and conflict with link escapes. If someone wants them, go ahead and implement =)
