### PR TITLE
Support YAML frontmatter headers v2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are not using any package manager, download the [tarball](https://github.
 
 ## Options
 
-**Disable Folding**
+### Disable Folding
 
 Add the following line to your `.vimrc` to disable folding.
 
@@ -45,7 +45,7 @@ Add the following line to your `.vimrc` to disable folding.
 let g:vim_markdown_folding_disabled=1
 ```
 
-**Set Initial Foldlevel**
+### Set Initial Foldlevel
 
 Add the following line to your `.vimrc` to set the initial foldlevel. This option defaults to 0 (i.e. all folds are closed) and is ignored if folding is disabled.
 
@@ -53,7 +53,7 @@ Add the following line to your `.vimrc` to set the initial foldlevel. This optio
 let g:vim_markdown_initial_foldlevel=1
 ```
 
-**Disable Default Key Mappings**
+### Disable Default Key Mappings
 
 Add the following line to your `.vimrc` to disable default key mappings. You can map them by yourself with `<Plug>` mappings.
 
@@ -61,15 +61,26 @@ Add the following line to your `.vimrc` to disable default key mappings. You can
 let g:vim_markdown_no_default_key_mappings=1
 ```
 
-**Syntax extensions**
+### Syntax extensions
 
-The following options control which syntax extensions will be turned on.
+The following options control which syntax extensions will be turned on. They are off by default.
 
-LaTeX math: `$ $`, `$$ $$`, escapable as `\$ \$` and `\$\$ \$\$`:
+#### LaTeX math
+
+Used as `$x^2$`, `$$x^2$$`, escapable as `\$x\$` and `\$\$x\$\$`.
 
 ```vim
 let g:vim_markdown_math=1
 ```
+
+#### YAML frontmatter
+
+Highlight YAML frontmatter as used by Jekyll:
+
+```vim
+let g:vim_markdown_frontmatter=1
+```
+
 ## Mappings
 
 The following work on normal and visual modes:

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -101,9 +101,11 @@ endif
 
 syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdMath,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
 
-" highlight YAML frontmatter
-syn include @yamlTop syntax/yaml.vim
-syntax match Comment /\%^---\_$\_.\{-}\_^---$/ contains=@yamlTop
+" YAML frontmatter
+if get(g:, 'vim_markdown_frontmatter', 0)
+  syn include @yamlTop syntax/yaml.vim
+  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop
+endif
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -72,3 +72,42 @@ Execute (multiline math):
   AssertNotEqual SyntaxOf('a'), 'mkdMath'
   AssertEqual SyntaxOf('b'), 'mkdMath'
   AssertNotEqual SyntaxOf('c'), 'mkdMath'
+
+# YAML frontmatter
+
+Given mkd;
+---
+a: b
+---
+
+Execute (YAML frontmatter is controlled by the option):
+  AssertNotEqual SyntaxOf('a'), 'yamlBlockMappingKey'
+  let g:vim_markdown_frontmatter=1
+  syn off | syn on
+  AssertEqual SyntaxOf('a'), 'yamlBlockMappingKey'
+  let g:vim_markdown_frontmatter=0
+  syn off | syn on
+  AssertNotEqual SyntaxOf('a'), 'yamlBlockMappingKey'
+
+Given mkd;
+
+---
+a: b
+---
+
+Execute (YAML frontmatter only works if it's the first thing in the file):
+  let g:vim_markdown_frontmatter=1
+  syn off | syn on
+  AssertNotEqual SyntaxOf('a'), 'yamlBlockMappingKey'
+
+Given mkd;
+---
+a: b
+---
+
+---
+
+Execute (rules are not mistaken by YAML frontmatter delimiters):
+  let g:vim_markdown_frontmatter=1
+  syn off | syn on
+  AssertEqual SyntaxAt(5, 1), 'mkdRule'


### PR DESCRIPTION
This patches https://github.com/plasticboy/vim-markdown/pull/66 to:
- include an option, turned off by default, to control if this is on or off
- use `region` instead of match, otherwise the `---` would be a part of the YAML too
