### PR TITLE
Respect global fold config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ If you are not using any package manager, download the [tarball](https://github.
 
 ### Disable Folding
 
-Add the following line to your `.vimrc` to disable folding.
+Add the following line to your `.vimrc` to disable folding configuration.
 
 ```vim
 let g:vim_markdown_folding_disabled=1
+```
+
+This option only controls vim_markdown's folding configuration. To enable/disable folding use Vim's folding configuration.
+
+```vim
+set [no]foldenable
 ```
 
 ### Set Initial Foldlevel

--- a/after/ftplugin/mkd.vim
+++ b/after/ftplugin/mkd.vim
@@ -45,12 +45,4 @@ if !get(g:, "vim_markdown_folding_disabled", 0)
     let g:vim_markdown_initial_foldlevel=0
   endif
   let &l:foldlevel=g:vim_markdown_initial_foldlevel
-
-  "---------- everything after this is optional -----------------------
-  " change the following fold options to your liking
-  " see ':help fold-options' for more
-  setlocal foldenable
-  setlocal foldcolumn=0
-  set foldmethod=expr
-  set foldopen-=search
 endif


### PR DESCRIPTION
Deleted the 'optional settings'  that override global fold configuration for markdown buffers.

These settings aren't really optional since there's no way to disable. Custom fold configuration in .vimrc should be respected, hence folding should not be enabled for the local buffer. IMO if users want folding (which is on by default anyway) they should `set foldenable`.
