### PR TITLE
Fix () [] were rendered as links when not in link 2

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -105,7 +105,7 @@ if get(g:, 'vim_markdown_frontmatter', 0)
   syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop
 endif
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -26,8 +26,11 @@ Execute (link with title):
 Given mkd;
 (a)
 
+(b)
+
 Execute (parenthesis not in link):
-  AssertNotEqual SyntaxOf('a'), 'mkdLink'
+  AssertNotEqual SyntaxOf('a'), 'mkdURL'
+  AssertNotEqual SyntaxOf('b'), 'mkdURL'
 
 Given mkd;
 [a](b) c [d](e)


### PR DESCRIPTION
Same as https://github.com/plasticboy/vim-markdown/pull/122, but I undid the other one on some merge conflict insanity + always passing test (it should be not mkdURL, not mkdLink, and the problem only occurs in paragraphs after the first).
