### PR TITLE
Tweaked underscore italics to prevent escaped ones from ending the match

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -36,7 +36,7 @@ syn sync linebreaks=1
 
 "additions to HTML groups
 syn region htmlItalic start="\\\@<!\*\S\@=" end="\S\@<=\\\@<!\*" keepend oneline
-syn region htmlItalic start="\(^\|\s\)\@<=_\|\\\@<!_\([^_]\+\s\)\@=" end="\S\@<=_\|_\S\@=" keepend oneline
+syn region htmlItalic start="\(^\|\s\)\@<=_\|\\\@<!_\([^_]\+\s\)\@=" end="\S\@<=[^\\]_\|[^\\]_\S\@=" keepend oneline
 syn region htmlBold start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend oneline
 syn region htmlBold start="\S\@<=__\|__\S\@=" end="\S\@<=__\|__\S\@=" keepend oneline
 syn region htmlBoldItalic start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend oneline


### PR DESCRIPTION
I'm not sure if this is necessarily the best solution, but this pull request resolves an issue where **italics** via **underscores**, with an _escaped_ **underscore** between them, stops the match as though it was the closing one. I tested to see if this issue occurs with **italics** via the **star** character, as well as for the possibility of similar issues popping up with either character for **bold** or **bold-italics**, but those all appear to work correctly.

You can see the issue for yourself by using the following test case: `print _err\_msg_ and abort the script` (the **italics** stop at the **underscore** immediately before **msg_** instead of including it like they should).

I noticed another (potentially related) issue while coming up with a test case for this one, by the way. When the escape character is the first character on a line, and it's escaping a **star** or **underscore**, the escape seemed to get ignored in all the cases I tested, resulting in the **star**/**underscore** immediately after the escape being treated (incorrectly) like markdown. I can make a separate issue out of this if you think it would make more sense to do so, but I figured I'd mention it here so you'd be aware of the problem (assuming you weren't already) before making any decisions in respect to this pull request. It would suck to spend time tweaking my solution and committing it, only to find out that your best bet is to wipe it all out :).

Anyway, thanks and have a good time of day- Cheers!
