### PR TITLE
Remove automatic setting of foldlevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,6 @@ This option only controls vim_markdown's folding configuration. To enable/disabl
 set [no]foldenable
 ```
 
-### Set Initial Foldlevel
-
-Add the following line to your `.vimrc` to set the initial foldlevel. This option defaults to 0 (i.e. all folds are closed) and is ignored if folding is disabled.
-
-```vim
-let g:vim_markdown_initial_foldlevel=1
-```
-
 ### Disable Default Key Mappings
 
 Add the following line to your `.vimrc` to disable default key mappings. You can map them by yourself with `<Plug>` mappings.

--- a/after/ftplugin/mkd.vim
+++ b/after/ftplugin/mkd.vim
@@ -39,10 +39,4 @@ endfunc
 if !get(g:, "vim_markdown_folding_disabled", 0)
   setlocal foldexpr=Foldexpr_markdown(v:lnum)
   setlocal foldmethod=expr
-
-  " allow the initial foldlevel to be configured in .vimrc
-  if !exists("g:vim_markdown_initial_foldlevel")
-    let g:vim_markdown_initial_foldlevel=0
-  endif
-  let &l:foldlevel=g:vim_markdown_initial_foldlevel
 endif


### PR DESCRIPTION
Vim already has a standard well known way of dealing with this with `set foldlevel`.

Let's not create another configuration which only raises the entry barrier.

Fix https://github.com/plasticboy/vim-markdown/issues/35

ping @ilikepi @shirosaki
