### PR TITLE
Change default new_list_item_indent from 4 to sw

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The following options control which syntax extensions will be turned on. They ar
         * item1
             * item2
 
-    vim-markdown automatically insert the indent. By default, the number of spaces of indent is 4. If you'd like to change the number as 2, just write:
+    vim-markdown automatically insert the indent. By default, the number of spaces of indent is the value of `shiftwidth`. If you'd like to change the number as 2, just write:
 
         let g:vim_markdown_new_list_item_indent = 2
 

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -408,7 +408,8 @@ Adjust new list item indent ~
       * item2
 <
   vim-markdown automatically insert the indent. By default, the number of
-  spaces of indent is 4. If you'd like to change the number as 2, just write:
+  spaces of indent is the value of 'shiftwidth'. If you'd like to change the
+  number as 2, just write:
 >
   let g:vim_markdown_new_list_item_indent = 2
 <

--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -48,7 +48,7 @@ function GetMarkdownIndent()
     if v:lnum > 2 && s:IsBlankLine(getline(v:lnum - 1)) && s:IsBlankLine(getline(v:lnum - 2))
         return 0
     endif
-    let list_ind = get(g:, "vim_markdown_new_list_item_indent", 4)
+    let list_ind = get(g:, "vim_markdown_new_list_item_indent", &shiftwidth)
     " Find a non-blank line above the current line.
     let lnum = s:PrevNonBlank(v:lnum - 1)
     " At the start of the file use zero indent.


### PR DESCRIPTION
This should get rid of indentation problems for people who have not manually set `g:vim_markdown_new_list_item_indent` but have a shiftwidth different from 4.

It was driving me nuts, trying to find the culprit amongst my plugins. I'm not an experienced Vim user and I barely know any Vimscript, so let me know if this is poor form or if there are more files I should be changing.