### PR TITLE
Handle multiline links with `gx` and `ge`

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -585,16 +585,26 @@ endfunction
 
 " Return the next position of the given syntax name,
 " inclusive on the given position.
-"
-" TODO: multiple lines
-"
 function! s:FindNextSyntax(lnum, col, name)
     let l:col = a:col
-    let l:step = 1
-    while synIDattr(synID(a:lnum, l:col, 1), 'name') !=# a:name
-        let l:col += l:step
+    let l:lnum = a:lnum
+    let l:linelen = strdisplaywidth(getline(l:lnum))
+
+    while 1
+        if l:col > l:linelen " if we're at the end of the line
+            if l:lnum < line('$') " if this is not the last line
+                let l:lnum += 1
+                let l:col = 0
+                let l:linelen = strdisplaywidth(getline(l:lnum))
+            else
+                throw "vim-markdown: FindNextSyntax failed"
+            end
+        elseif synIDattr(synID(l:lnum, l:col, 1), 'name') ==# a:name
+            return [l:lnum, l:col]
+        else
+            let l:col += 1
+        endif
     endwhile
-    return [a:lnum, l:col]
 endfunction
 
 function! s:FindCornersOfSyntax(lnum, col)

--- a/test/map.vader
+++ b/test/map.vader
@@ -59,6 +59,15 @@ Execute (ge opens file):
   AssertEqual getline(1), 'ge test'
 
 Given markdown;
+[This is a long link that
+spans across two lines](ge_test.md)
+
+Execute (ge opens file with multiline link):
+  normal ge
+  AssertEqual @%, 'ge_test.md'
+  AssertEqual getline(1), 'ge test'
+
+Given markdown;
 [ge_test](ge_test)
 
 Execute (ge opens file without .md extensions):


### PR DESCRIPTION
Previously, `gx` and `ge` within a multiline link would cause an
infinite loop inside of `s:FindNextSyntax`. This commit makes
`s:FindNextSyntax` search across multiple lines, and throw an error if
it fails.