### PR TITLE
Change shortcut: MoveToCurHeader: `]c` -> `]h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ The following work on normal and visual modes:
 
 -   `]]`: go to next header. `<Plug>Markdown_MoveToNextHeader`
 
--   `[[`: go to previous header. Contrast with `]c`. `<Plug>Markdown_MoveToPreviousHeader`
+-   `[[`: go to previous header. Contrast with `]h`. `<Plug>Markdown_MoveToPreviousHeader`
 
 -   `][`: go to next sibling header if any. `<Plug>Markdown_MoveToNextSiblingHeader`
 
 -   `[]`: go to previous sibling header if any. `<Plug>Markdown_MoveToPreviousSiblingHeader`
 
--   `]c`: go to Current header. `<Plug>Markdown_MoveToCurHeader`
+-   `]h`: go to Current header. `<Plug>Markdown_MoveToCurHeader`
 
 -   `]u`: go to parent header (Up). `<Plug>Markdown_MoveToParentHeader`
 

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -525,7 +525,7 @@ The following work on normal and visual modes:
 - ']]': go to next header. '<Plug>Markdown_MoveToNextHeader'
 
                                                               *vim-markdown-[[*
-- '[[': go to previous header. Contrast with ']c'.
+- '[[': go to previous header. Contrast with ']h'.
   '<Plug>Markdown_MoveToPreviousHeader'
 
                                                               *vim-markdown-][*
@@ -536,8 +536,8 @@ The following work on normal and visual modes:
 - '[]': go to previous sibling header if any.
   '<Plug>Markdown_MoveToPreviousSiblingHeader'
 
-                                                              *vim-markdown-]c*
-- ']c': go to Current header. '<Plug>Markdown_MoveToCurHeader'
+                                                              *vim-markdown-]h*
+- ']h': go to Current header. '<Plug>Markdown_MoveToCurHeader'
 
                                                               *vim-markdown-]u*
 - ']u': go to parent header (Up). '<Plug>Markdown_MoveToParentHeader'

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -750,7 +750,7 @@ if !get(g:, 'vim_markdown_no_default_key_mappings', 0)
     call <sid>MapNotHasmapto('][', 'Markdown_MoveToNextSiblingHeader')
     call <sid>MapNotHasmapto('[]', 'Markdown_MoveToPreviousSiblingHeader')
     call <sid>MapNotHasmapto(']u', 'Markdown_MoveToParentHeader')
-    call <sid>MapNotHasmapto(']c', 'Markdown_MoveToCurHeader')
+    call <sid>MapNotHasmapto(']h', 'Markdown_MoveToCurHeader')
     call <sid>MapNotHasmapto('gx', 'Markdown_OpenUrlUnderCursor')
     call <sid>MapNotHasmapto('ge', 'Markdown_EditUrlUnderCursor')
 endif

--- a/test/map.vader
+++ b/test/map.vader
@@ -146,8 +146,8 @@ Given markdown;
 
 b
 
-Execute (]c):
+Execute (]h):
   normal! 3G
   AssertEqual line('.'), 3
-  normal ]c
+  normal ]h
   AssertEqual line('.'), 1


### PR DESCRIPTION
Shortcut key `]c` overrides diff-next-change jump.

Users can use diff-mode for Markdown files, so the shortcut should be another.