### PR TITLE
make Markdown_EditUrlUnderCursor fall back to builtin gf

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The following work on normal and visual modes:
 
     Known limitation: does not work for links that span multiple lines.
 
--   `ge`: open the link under the cursor in Vim for editing. Useful for relative markdown links. `<Plug>Markdown_EditUrlUnderCursor`
+-   `ge`: open the link under the cursor in Vim for editing. Useful for relative markdown links. Falls back to `gf` with force editing, if not on a markdown link. `<Plug>Markdown_EditUrlUnderCursor`
 
     The rules for the cursor position are the same as the `gx` command.
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -664,6 +664,22 @@ endfunction
 " script while this function is running. We must not replace it.
 if !exists('*s:EditUrlUnderCursor')
     function s:EditUrlUnderCursor()
+        let l:editmethod = ''
+        " determine how to open the linked file (split, tab, etc)
+        if exists('g:vim_markdown_edit_url_in')
+          if g:vim_markdown_edit_url_in == 'tab'
+            let l:editmethod = 'tabnew'
+          elseif g:vim_markdown_edit_url_in == 'vsplit'
+            let l:editmethod = 'vsp'
+          elseif g:vim_markdown_edit_url_in == 'hsplit'
+            let l:editmethod = 'sp'
+          else
+            let l:editmethod = 'edit'
+          endif
+        else
+          " default to current buffer
+          let l:editmethod = 'edit'
+        endif
         let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
         if l:url != ''
             if get(g:, 'vim_markdown_autowrite', 0)
@@ -693,29 +709,13 @@ if !exists('*s:EditUrlUnderCursor')
                     endif
                 endif
                 let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
-                let l:editmethod = ''
-                " determine how to open the linked file (split, tab, etc)
-                if exists('g:vim_markdown_edit_url_in')
-                  if g:vim_markdown_edit_url_in == 'tab'
-                    let l:editmethod = 'tabnew'
-                  elseif g:vim_markdown_edit_url_in == 'vsplit'
-                    let l:editmethod = 'vsp'
-                  elseif g:vim_markdown_edit_url_in == 'hsplit'
-                    let l:editmethod = 'sp'
-                  else
-                    let l:editmethod = 'edit'
-                  endif
-                else
-                  " default to current buffer
-                  let l:editmethod = 'edit'
-                endif
                 execute l:editmethod l:url
             endif
             if l:anchor != ''
                 silent! execute '/'.l:anchor
             endif
         else
-            echomsg 'The cursor is not on a link.'
+            execute l:editmethod . " <cfile>"
         endif
     endfunction
 endif


### PR DESCRIPTION
This is to allow for NOT using `ge`, rather just stick with the built-in `gf` for editing files, with a mapping such as this:
```
autocmd FileType markdown nmap <buffer>gf <Plug>Markdown_EditUrlUnderCursor
```
Why edit if it exists:

:h gf
> If you do want to edit a new file, use: >
> :e <cfile>
> To make gf always work like that: >
> :map gf :e <cfile><CR>

Since Markdown_EditUrlUnderCursor behaves this way already
going with the edit always is a more logical fallback.