### PR TITLE
Fix TableFormat for indented tables

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -550,7 +550,7 @@ function! s:TableFormat()
     " Move colons for alignment to left or right side of the cell.
     execute 's/:\( \+\)|/\1:|/e' . l:flags
     execute 's/|\( \+\):/|:\1/e' . l:flags
-    execute 's/ /-/' . l:flags
+    execute 's/|\zs \+\ze|/\=repeat("-", len(submatch(0)))/' . l:flags
     call setpos('.', l:pos)
 endfunction
 


### PR DESCRIPTION
Problem: TableFormat adds hyphens at the left of the indented table like
this:

```
  | a | b |
--|---|---|
  | x | y |
```

Solution: Replace only the spaces between pipes.