### PR TITLE
Add CI‌ jobs to lint vimscript, run regression tests, and comment on PRs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,13 @@
+name: Reviewdog
+on: [pull_request]
+jobs:
+  vint:
+    name: vint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: vint
+        uses: reviewdog/action-vint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review

--- a/.github/workflows/vader.yml
+++ b/.github/workflows/vader.yml
@@ -1,0 +1,31 @@
+name: Vader
+on: [push, pull_request]
+jobs:
+  vader:
+    name: vader
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        vimFlavor: ["vim", "nvim"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Enable Universe package repository
+      run: |
+        sudo add-apt-repository universe
+        sudo apt-get update
+    - name: Install ${{ matrix.vimFlavor }}
+      run: |
+        sudo apt-get install ${{ matrix.vimFlavor == 'nvim' && 'neovim' || 'vim' }}
+    - name: Review versions
+      run: |
+        ${{ matrix.vimFlavor }} --version
+    - name: Fetch Vader and other dependencies
+      run: |
+        make build/tabular build/vim-toml build/vim-json build/vader.vim
+    - name: Run test suite
+      run: |
+        cd test
+        ${{ matrix.vimFlavor == 'nvim' && 'nvim --headless' || 'vim -N' }} \
+          -u vimrc "+Vader! *"

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -1,0 +1,15 @@
+name: Vint
+on: [push]
+jobs:
+  vint:
+    name: vint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Setup dependencies
+        run: pip install vim-vint
+      - name: Lint Vimscript
+        run: vint .

--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+cmdargs:
+  severity: style_problem
+  color: true
+  env:
+    neovim: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Vim Markdown
 
+[![Vint](https://github.com/preservim/vim-markdown/workflows/Vint/badge.svg)](https://github.com/preservim/vim-markdown/actions?workflow=Vint)
+[![Vader](https://github.com/preservim/vim-markdown/workflows/Vader/badge.svg)](https://github.com/preservim/vim-markdown/actions?workflow=Vader)
+
 Syntax highlighting, matching rules and mappings for [the original Markdown](http://daringfireball.net/projects/markdown/) and extensions.
 
 1. [Installation](#installation)
@@ -441,7 +444,7 @@ The following requires `:filetype plugin on`.
 
 The main contributors of vim-markdown are:
 
-- **Ben Williams** (A.K.A. @plasticboy). The original developer of vim-markdown. [Homepage](http://plasticboy.com/).
+- **Ben Williams** (A.K.A. **@plasticboy**). The original developer of vim-markdown. [Homepage](http://plasticboy.com/).
 
 If you feel that your name should be on this list, please make a pull request listing your contributions.
 

--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -87,7 +87,7 @@ if get(g:, 'vim_markdown_folding_style_pythonic', 0)
     function! Foldtext_markdown()
         let line = getline(v:foldstart)
         let has_numbers = &number || &relativenumber
-        let nucolwidth = &fdc + has_numbers * &numberwidth
+        let nucolwidth = &foldcolumn + has_numbers * &numberwidth
         let windowwidth = winwidth(0) - nucolwidth - 6
         let foldedlinecount = v:foldend - v:foldstart
         let line = strpart(line, 0, windowwidth - 2 -len(foldedlinecount))

--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -12,7 +12,7 @@ function! s:is_mkdCode(lnum)
     return (name =~# '^mkd\%(Code$\|Snippet\)' || name !=# '' && name !~? '^\%(mkd\|html\)')
 endfunction
 
-if get(g:, "vim_markdown_folding_style_pythonic", 0)
+if get(g:, 'vim_markdown_folding_style_pythonic', 0)
     function! Foldexpr_markdown(lnum)
         let l1 = getline(a:lnum)
         "~~~~~ keep track of fenced code blocks ~~~~~
@@ -93,7 +93,7 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
         let line = strpart(line, 0, windowwidth - 2 -len(foldedlinecount))
         let line = substitute(line, '\%("""\|''''''\)', '', '')
         let fillcharcount = windowwidth - len(line) - len(foldedlinecount) + 1
-        return line . ' ' . repeat("-", fillcharcount) . ' ' . foldedlinecount
+        return line . ' ' . repeat('-', fillcharcount) . ' ' . foldedlinecount
     endfunction
 else " vim_markdown_folding_style_pythonic == 0
     function! Foldexpr_markdown(lnum)
@@ -168,12 +168,12 @@ endif
 
 let b:fenced_block = 0
 let b:front_matter = 0
-let s:vim_markdown_folding_level = get(g:, "vim_markdown_folding_level", 1)
+let s:vim_markdown_folding_level = get(g:, 'vim_markdown_folding_level', 1)
 
 function! s:MarkdownSetupFolding()
-    if !get(g:, "vim_markdown_folding_disabled", 0)
-        if get(g:, "vim_markdown_folding_style_pythonic", 0)
-            if get(g:, "vim_markdown_override_foldtext", 1)
+    if !get(g:, 'vim_markdown_folding_disabled', 0)
+        if get(g:, 'vim_markdown_folding_style_pythonic', 0)
+            if get(g:, 'vim_markdown_override_foldtext', 1)
                 setlocal foldtext=Foldtext_markdown()
             endif
         endif
@@ -183,9 +183,9 @@ function! s:MarkdownSetupFolding()
 endfunction
 
 function! s:MarkdownSetupFoldLevel()
-    if get(g:, "vim_markdown_folding_style_pythonic", 0)
+    if get(g:, 'vim_markdown_folding_style_pythonic', 0)
         " set default foldlevel
-        execute "setlocal foldlevel=".s:vim_markdown_folding_level
+        execute 'setlocal foldlevel='.s:vim_markdown_folding_level
     endif
 endfunction
 

--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -9,7 +9,7 @@
 
 function! s:is_mkdCode(lnum)
     let name = synIDattr(synID(a:lnum, 1, 0), 'name')
-    return (name =~ '^mkd\%(Code$\|Snippet\)' || name != '' && name !~ '^\%(mkd\|html\)')
+    return (name =~# '^mkd\%(Code$\|Snippet\)' || name !=# '' && name !~? '^\%(mkd\|html\)')
 endfunction
 
 if get(g:, "vim_markdown_folding_style_pythonic", 0)
@@ -17,7 +17,7 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
         let l1 = getline(a:lnum)
         "~~~~~ keep track of fenced code blocks ~~~~~
         "If we hit a code block fence
-        if l1 =~ '````*' || l1 =~ '\~\~\~\~*'
+        if l1 =~# '````*' || l1 =~# '\~\~\~\~*'
             " toggle the variable that says if we're in a code block
             if b:fenced_block == 0
                 let b:fenced_block = 1
@@ -30,14 +30,14 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
             if b:front_matter == 1 && a:lnum > 2
                 let l0 = getline(a:lnum-1)
                 " if the previous line fenced front matter
-                if l0 == '---'
+                if l0 ==# '---'
                     " we must not be in front matter
                     let b:front_matter = 0
                 endif
             " else, if we're on line one
             elseif a:lnum == 1
                 " if we hit a front matter fence
-                if l1 == '---'
+                if l1 ==# '---'
                     " we're in the front matter
                     let b:front_matter = 1
                 endif
@@ -45,8 +45,8 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
         endif
 
         " if we're in a code block or front matter
-        if b:fenced_block == 1 || b:front_matter == 1
-            if a:lnum == 1
+        if b:fenced_block ==# 1 || b:front_matter ==# 1
+            if a:lnum ==# 1
                 " fold any 'preamble'
                 return '>1'
             else
@@ -58,18 +58,18 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
         let l2 = getline(a:lnum+1)
         " if the next line starts with two or more '='
         " and is not code
-        if l2 =~ '^==\+\s*' && !s:is_mkdCode(a:lnum+1)
+        if l2 =~# '^==\+\s*' && !s:is_mkdCode(a:lnum+1)
             " next line is underlined (level 1)
             return '>0'
         " else, if the nex line starts with two or more '-'
         " and is not code
-        elseif l2 =~ '^--\+\s*' && !s:is_mkdCode(a:lnum+1)
+        elseif l2 =~# '^--\+\s*' && !s:is_mkdCode(a:lnum+1)
             " next line is underlined (level 2)
             return '>1'
         endif
 
         "if we're on a non-code line starting with a pound sign
-        if l1 =~ '^#' && !s:is_mkdCode(a:lnum)
+        if l1 =~# '^#' && !s:is_mkdCode(a:lnum)
             " set the fold level to the number of hashes -1
             " return '>'.(matchend(l1, '^#\+') - 1)
             " set the fold level to the number of hashes
@@ -104,7 +104,7 @@ else " vim_markdown_folding_style_pythonic == 0
         endif
 
         " keep track of fenced code blocks
-        if l0 =~ '````*' || l0 =~ '\~\~\~\~*'
+        if l0 =~# '````*' || l0 =~# '\~\~\~\~*'
             if b:fenced_block == 0
                 let b:fenced_block = 1
             elseif b:fenced_block == 1
@@ -112,11 +112,11 @@ else " vim_markdown_folding_style_pythonic == 0
             endif
         elseif g:vim_markdown_frontmatter == 1
             if b:front_matter == 1
-                if l0 == '---'
+                if l0 ==# '---'
                     let b:front_matter = 0
                 endif
             elseif a:lnum == 2
-                if l0 == '---'
+                if l0 ==# '---'
                     let b:front_matter = 1
                 endif
             endif
@@ -128,10 +128,10 @@ else " vim_markdown_folding_style_pythonic == 0
         endif
 
         let l2 = getline(a:lnum+1)
-        if  l2 =~ '^==\+\s*' && !s:is_mkdCode(a:lnum+1)
+        if  l2 =~# '^==\+\s*' && !s:is_mkdCode(a:lnum+1)
             " next line is underlined (level 1)
             return '>1'
-        elseif l2 =~ '^--\+\s*' && !s:is_mkdCode(a:lnum+1)
+        elseif l2 =~# '^--\+\s*' && !s:is_mkdCode(a:lnum+1)
             " next line is underlined (level 2)
             if s:vim_markdown_folding_level >= 2
                 return '>1'
@@ -141,7 +141,7 @@ else " vim_markdown_folding_style_pythonic == 0
         endif
 
         let l1 = getline(a:lnum)
-        if l1 =~ '^#' && !s:is_mkdCode(a:lnum)
+        if l1 =~# '^#' && !s:is_mkdCode(a:lnum)
             " fold level according to option
             if s:vim_markdown_folding_level == 1 || matchend(l1, '^#\+') > s:vim_markdown_folding_level
                 if a:lnum == line('$')
@@ -155,7 +155,7 @@ else " vim_markdown_folding_style_pythonic == 0
             endif
         endif
 
-        if l0 =~ '^#' && !s:is_mkdCode(a:lnum-1)
+        if l0 =~# '^#' && !s:is_mkdCode(a:lnum-1)
             " previous line starts with hashes
             return '>'.matchend(l0, '^#\+')
         else

--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,8 +1,12 @@
+augroup VimMarkdown
+    autocmd!
+augroup END
+
 if !has('patch-7.4.480')
     " Before this patch, vim used modula2 for .md.
-    au! filetypedetect BufRead,BufNewFile *.md
+    au! VimMarkdown filetypedetect BufRead,BufNewFile *.md
 endif
 
 " markdown filetype file
-au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
-au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown
+au VimMarkdown BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
+au VimMarkdown BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -94,7 +94,7 @@ endfunction
 "
 function! s:MoveToCurHeader()
     let l:lineNum = s:GetHeaderLineNum()
-    if l:lineNum != 0
+    if l:lineNum !=# 0
         call cursor(l:lineNum, 1)
     else
         echo 'outside any header'
@@ -147,7 +147,7 @@ function! s:GetHeaderLevel(...)
         let l:line = a:1
     endif
     let l:linenum = s:GetHeaderLineNum(l:line)
-    if l:linenum != 0
+    if l:linenum !=# 0
         return s:GetLevelOfHeaderAtLine(l:linenum)
     else
         return 0
@@ -167,7 +167,7 @@ function! s:GetHeaderList()
         let l:l1 = getline(i+1)
         let l:line = substitute(l:lineraw, "#", "\\\#", "g")
         " exclude lines in fenced code blocks
-        if l:line =~ '````*' || l:line =~ '\~\~\~\~*'
+        if l:line =~# '````*' || l:line =~# '\~\~\~\~*'
             if l:fenced_block == 0
                 let l:fenced_block = 1
             elseif l:fenced_block == 1
@@ -176,22 +176,22 @@ function! s:GetHeaderList()
         " exclude lines in frontmatters
         elseif l:vim_markdown_frontmatter == 1
             if l:front_matter == 1
-                if l:line == '---'
+                if l:line ==# '---'
                     let l:front_matter = 0
                 endif
             elseif i == 1
-                if l:line == '---'
+                if l:line ==# '---'
                     let l:front_matter = 1
                 endif
             endif
         endif
         " match line against header regex
-        if join(getline(i, i + 1), "\n") =~ s:headersRegexp && l:line =~ '^\S'
+        if join(getline(i, i + 1), "\n") =~# s:headersRegexp && l:line =~# '^\S'
             let l:is_header = 1
         else
             let l:is_header = 0
         endif
-        if l:is_header == 1 && l:fenced_block == 0 && l:front_matter == 0
+        if l:is_header ==# 1 && l:fenced_block ==# 0 && l:front_matter ==# 0
             " remove hashes from atx headers
             if match(l:line, "^#") > -1
                 let l:line = substitute(l:line, '\v^#*[ ]*', '', '')
@@ -653,7 +653,7 @@ endfunction
 "
 function! s:OpenUrlUnderCursor()
     let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
-    if l:url != ''
+    if l:url !=# ''
         call s:VersionAwareNetrwBrowseX(l:url)
     else
         echomsg 'The cursor is not on a link.'
@@ -665,7 +665,7 @@ endfunction
 if !exists('*s:EditUrlUnderCursor')
     function s:EditUrlUnderCursor()
         let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
-        if l:url != ''
+        if l:url !=# ''
             if get(g:, 'vim_markdown_autowrite', 0)
                 write
             endif
@@ -675,14 +675,14 @@ if !exists('*s:EditUrlUnderCursor')
                 if len(l:parts) == 2
                     let [l:url, l:anchor] = parts
                     let l:anchorexpr = get(g:, 'vim_markdown_anchorexpr', '')
-                    if l:anchorexpr != ''
+                    if l:anchorexpr !=# ''
                         let l:anchor = eval(substitute(
                             \ l:anchorexpr, 'v:anchor',
                             \ escape('"'.l:anchor.'"', '"'), ''))
                     endif
                 endif
             endif
-            if l:url != ''
+            if l:url !=# ''
                 let l:ext = ''
                 if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
                     " use another file extension if preferred
@@ -696,11 +696,11 @@ if !exists('*s:EditUrlUnderCursor')
                 let l:editmethod = ''
                 " determine how to open the linked file (split, tab, etc)
                 if exists('g:vim_markdown_edit_url_in')
-                  if g:vim_markdown_edit_url_in == 'tab'
+                  if g:vim_markdown_edit_url_in ==# 'tab'
                     let l:editmethod = 'tabnew'
-                  elseif g:vim_markdown_edit_url_in == 'vsplit'
+                  elseif g:vim_markdown_edit_url_in ==# 'vsplit'
                     let l:editmethod = 'vsp'
-                  elseif g:vim_markdown_edit_url_in == 'hsplit'
+                  elseif g:vim_markdown_edit_url_in ==# 'hsplit'
                     let l:editmethod = 'sp'
                   else
                     let l:editmethod = 'edit'
@@ -711,7 +711,7 @@ if !exists('*s:EditUrlUnderCursor')
                 endif
                 execute l:editmethod l:url
             endif
-            if l:anchor != ''
+            if l:anchor !=# ''
                 silent! execute '/'.l:anchor
             endif
         else
@@ -789,7 +789,7 @@ function! s:MarkdownHighlightSources(force)
     let filetypes = {}
     for line in getline(1, '$')
         let ft = matchstr(line, '```\s*\zs[0-9A-Za-z_+-]*\ze.*')
-        if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
+        if !empty(ft) && ft !~# '^\d*$' | let filetypes[ft] = 1 | endif
     endfor
     if !exists('b:mkd_known_filetypes')
         let b:mkd_known_filetypes = {}
@@ -854,13 +854,13 @@ endfunction
 
 
 function! s:MarkdownRefreshSyntax(force)
-    if &filetype =~ 'markdown' && line('$') > 1
+    if &filetype =~# 'markdown' && line('$') > 1
         call s:MarkdownHighlightSources(a:force)
     endif
 endfunction
 
 function! s:MarkdownClearSyntaxVariables()
-    if &filetype =~ 'markdown'
+    if &filetype =~# 'markdown'
         unlet! b:mkd_included_filetypes
     endif
 endfunction

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -550,7 +550,7 @@ function! s:TableFormat()
     " Move colons for alignment to left or right side of the cell.
     execute 's/:\( \+\)|/\1:|/e' . l:flags
     execute 's/|\( \+\):/|:\1/e' . l:flags
-    execute 's/|\zs \+\ze|/\=repeat("-", len(submatch(0)))/' . l:flags
+    execute 's/ /-/' . l:flags
     call setpos('.', l:pos)
 endfunction
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -161,11 +161,11 @@ function! s:GetHeaderList()
     let l:fenced_block = 0
     let l:front_matter = 0
     let l:header_list = []
-    let l:vim_markdown_frontmatter = get(g:, "vim_markdown_frontmatter", 0)
+    let l:vim_markdown_frontmatter = get(g:, 'vim_markdown_frontmatter', 0)
     for i in range(1, line('$'))
         let l:lineraw = getline(i)
         let l:l1 = getline(i+1)
-        let l:line = substitute(l:lineraw, "#", "\\\#", "g")
+        let l:line = substitute(l:lineraw, '#', "\\\#", 'g')
         " exclude lines in fenced code blocks
         if l:line =~# '````*' || l:line =~# '\~\~\~\~*'
             if l:fenced_block == 0
@@ -193,7 +193,7 @@ function! s:GetHeaderList()
         endif
         if l:is_header ==# 1 && l:fenced_block ==# 0 && l:front_matter ==# 0
             " remove hashes from atx headers
-            if match(l:line, "^#") > -1
+            if match(l:line, '^#') > -1
                 let l:line = substitute(l:line, '\v^#*[ ]*', '', '')
                 let l:line = substitute(l:line, '\v[ ]*#*$', '', '')
             endif
@@ -361,11 +361,11 @@ function! s:Toc(...)
     let l:header_list = s:GetHeaderList()
     let l:indented_header_list = []
     if len(l:header_list) == 0
-        echom "Toc: No headers."
+        echom 'Toc: No headers.'
         return
     endif
     let l:header_max_len = 0
-    let l:vim_markdown_toc_autofit = get(g:, "vim_markdown_toc_autofit", 0)
+    let l:vim_markdown_toc_autofit = get(g:, 'vim_markdown_toc_autofit', 0)
     for h in l:header_list
         " set header number of the cursor position
         if l:cursor_header == 0
@@ -438,7 +438,7 @@ function! s:InsertToc(format, ...)
     let l:toc = []
     let l:header_list = s:GetHeaderList()
     if len(l:header_list) == 0
-        echom "InsertToc: No headers."
+        echom 'InsertToc: No headers.'
         return
     endif
 
@@ -770,8 +770,8 @@ command! -buffer -nargs=? InsertNToc call s:InsertToc('numbers', <args>)
 if exists('g:vim_markdown_fenced_languages')
     let s:filetype_dict = {}
     for s:filetype in g:vim_markdown_fenced_languages
-        let key = matchstr(s:filetype, "[^=]*")
-        let val = matchstr(s:filetype, "[^=]*$")
+        let key = matchstr(s:filetype, '[^=]*')
+        let val = matchstr(s:filetype, '[^=]*$')
         let s:filetype_dict[key] = val
     endfor
 else
@@ -812,7 +812,7 @@ function! s:MarkdownHighlightSources(force)
             else
                 let filetype = ft
             endif
-            let group = 'mkdSnippet' . toupper(substitute(filetype, "[+-]", "_", "g"))
+            let group = 'mkdSnippet' . toupper(substitute(filetype, '[+-]', '_', 'g'))
             if !has_key(b:mkd_included_filetypes, filetype)
                 let include = s:SyntaxInclude(filetype)
                 let b:mkd_included_filetypes[filetype] = 1

--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -1,4 +1,4 @@
-if exists("b:did_indent") | finish | endif
+if exists('b:did_indent') | finish | endif
 let b:did_indent = 1
 
 setlocal indentexpr=GetMarkdownIndent()
@@ -8,7 +8,7 @@ setlocal autoindent
 " Automatically continue blockquote on line break
 setlocal formatoptions+=r
 setlocal comments=b:>
-if get(g:, "vim_markdown_auto_insert_bullets", 1)
+if get(g:, 'vim_markdown_auto_insert_bullets', 1)
     " Do not automatically insert bullets when auto-wrapping with text-width
     setlocal formatoptions-=c
     " Accept various markers as bullets
@@ -16,7 +16,7 @@ if get(g:, "vim_markdown_auto_insert_bullets", 1)
 endif
 
 " Only define the function once
-if exists("*GetMarkdownIndent") | finish | endif
+if exists('*GetMarkdownIndent') | finish | endif
 
 function! s:IsMkdCode(lnum)
     let name = synIDattr(synID(a:lnum, 1, 0), 'name')
@@ -48,7 +48,7 @@ function GetMarkdownIndent()
     if v:lnum > 2 && s:IsBlankLine(getline(v:lnum - 1)) && s:IsBlankLine(getline(v:lnum - 2))
         return 0
     endif
-    let list_ind = get(g:, "vim_markdown_new_list_item_indent", 4)
+    let list_ind = get(g:, 'vim_markdown_new_list_item_indent', 4)
     " Find a non-blank line above the current line.
     let lnum = s:PrevNonBlank(v:lnum - 1)
     " At the start of the file use zero indent.

--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -20,20 +20,20 @@ if exists("*GetMarkdownIndent") | finish | endif
 
 function! s:IsMkdCode(lnum)
     let name = synIDattr(synID(a:lnum, 1, 0), 'name')
-    return (name =~ '^mkd\%(Code$\|Snippet\)' || name != '' && name !~ '^\%(mkd\|html\)')
+    return (name =~# '^mkd\%(Code$\|Snippet\)' || name !=# '' && name !~? '^\%(mkd\|html\)')
 endfunction
 
 function! s:IsLiStart(line)
-    return a:line !~ '^ *\([*-]\)\%( *\1\)\{2}\%( \|\1\)*$' &&
-      \    a:line =~ '^\s*[*+-] \+'
+    return a:line !~# '^ *\([*-]\)\%( *\1\)\{2}\%( \|\1\)*$' &&
+      \    a:line =~# '^\s*[*+-] \+'
 endfunction
 
 function! s:IsHeaderLine(line)
-    return a:line =~ '^\s*#'
+    return a:line =~# '^\s*#'
 endfunction
 
 function! s:IsBlankLine(line)
-    return a:line =~ '^$'
+    return a:line =~# '^$'
 endfunction
 
 function! s:PrevNonBlank(lnum)

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -19,7 +19,7 @@ endif
 
 if version < 600
   syntax clear
-elseif exists("b:current_syntax")
+elseif exists('b:current_syntax')
   finish
 endif
 
@@ -178,7 +178,7 @@ HtmlHiLink mkdLinkDefTarget mkdURL
 HtmlHiLink mkdLinkTitle     htmlString
 HtmlHiLink mkdDelimiter     Delimiter
 
-let b:current_syntax = "mkd"
+let b:current_syntax = 'mkd'
 
 delcommand HtmlHiLink
 " vim: ts=8

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -7,7 +7,7 @@
 
 
 " Read the HTML syntax to start with
-if version < 600
+if v:version < 600
   so <sfile>:p:h/html.vim
 else
   runtime! syntax/html.vim
@@ -17,14 +17,14 @@ else
   endif
 endif
 
-if version < 600
+if v:version < 600
   syntax clear
 elseif exists('b:current_syntax')
   finish
 endif
 
 " don't use standard HiLink, it will not work with included syntax files
-if version < 508
+if v:version < 508
   command! -nargs=+ HtmlHiLink hi link <args>
 else
   command! -nargs=+ HtmlHiLink hi def link <args>

--- a/test/folding-toc.vader
+++ b/test/folding-toc.vader
@@ -2,6 +2,7 @@
 
 Before:
   source ../after/ftplugin/markdown.vim
+  setlocal foldtext=foldtext()
 
 After:
   setlocal foldexpr=0

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,16 +1,17 @@
 set nocompatible
-set rtp+=../
-set rtp+=../build/tabular/
-set rtp+=../build/vim-toml/
-set rtp+=../build/vim-json/
-set rtp+=../build/vader.vim/
-set rtp-=~/.vim
-set rtp-=~/.vim/after
+
 let $LANG='en_US'
+
+filetype off
+set runtimepath+=../
+set runtimepath+=../build/tabular/
+set runtimepath+=../build/vim-toml/
+set runtimepath+=../build/vim-json/
+set runtimepath+=../build/vader.vim/
 filetype on
-filetype plugin on
-filetype indent on
-syntax on
+
+filetype plugin indent on
+syntax enable
 
 function! Markdown_GetScriptID(fname) abort
     let l:snlist = ''
@@ -24,6 +25,7 @@ function! Markdown_GetScriptID(fname) abort
         endif
     endfor
 endfunction
+
 function! Markdown_GetFunc(fname, funcname) abort
     return function('<SNR>' . Markdown_GetScriptID(a:fname) . '_' . a:funcname)
 endfunction


### PR DESCRIPTION
Besides adding the CI jobs, this also refactors much of the vimscript to pass lint tests and adapts the test suite to work on both VIM and NeoVIM.