### PR TITLE
Fix TableFormat for indented tables, version 2

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -550,7 +550,7 @@ function! s:TableFormat()
     " Move colons for alignment to left or right side of the cell.
     execute 's/:\( \+\)|/\1:|/e' . l:flags
     execute 's/|\( \+\):/|:\1/e' . l:flags
-    execute 's/ /-/' . l:flags
+    execute 's/|:\?\zs[ -]\+\ze:\?|/\=repeat("-", len(submatch(0)))/' . l:flags
     call setpos('.', l:pos)
 endfunction
 

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -30,6 +30,19 @@ Expect (table is not modified):
   |---|---|
   | c | d |
 
+Given markdown (indented table);
+  | a | b |
+  |---|---|
+  | c | d |
+
+Execute (format well formatted, indented table):
+  TableFormat
+
+Expect (table is not modified):
+    | a | b |
+    |---|---|
+    | c | d |
+
 Given markdown;
 | left |right|  center  ||
 | :- | --: |:---:|:|
@@ -42,3 +55,16 @@ Expect (preserve colons to align text):
   | left | right | center |   |
   |:-----|------:|:------:|:--|
   | left | right | center |   |
+
+Given markdown (indented table with colons);
+  | left |right|  center  ||
+  | :- | --: |:---:|:|
+  | left |right|  center  ||
+
+Execute (format indented table with colons):
+  TableFormat
+
+Expect (preserve colons to align text):
+    | left | right | center |   |
+    |:-----|------:|:------:|:--|
+    | left | right | center |   |


### PR DESCRIPTION
Improved version of 6fe1a105302ad5b7a79e6346051c34dcc16cee70 that doesn't get fooled by colons.