### PR TITLE
Revert "refactor: Execute autocmd in group scope"

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -3,6 +3,6 @@ if !has('patch-7.4.480')
     au! filetypedetect BufRead,BufNewFile *.md
 endif
 
-" markdown filetype file
+" vint: -ProhibitAutocmdWithNoGroup
 au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
 au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown

--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,12 +1,8 @@
-augroup VimMarkdown
-    autocmd!
-augroup END
-
 if !has('patch-7.4.480')
     " Before this patch, vim used modula2 for .md.
-    au! VimMarkdown filetypedetect BufRead,BufNewFile *.md
+    au! filetypedetect BufRead,BufNewFile *.md
 endif
 
 " markdown filetype file
-au VimMarkdown BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
-au VimMarkdown BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown
+au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
+au BufRead,BufNewFile *.{md,mdx,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown


### PR DESCRIPTION
This reverts commit 18ed14af66ed1af7ecc612540b50acf51e55a23d.

Do not need `augroup` for `ftdetect`, see `:h ftdetect`, and
`filetypedetect` may is a autocmd group name.