### PR TITLE
Disable code block syntax highlighting when syntax=OFF

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -854,7 +854,11 @@ endfunction
 
 
 function! s:MarkdownRefreshSyntax(force)
-    if &filetype =~# 'markdown' && line('$') > 1
+    " Use != to compare &syntax's value to use the same logic run on
+    " $VIMRUNTIME/syntax/synload.vim.
+    "
+    " vint: next-line -ProhibitEqualTildeOperator
+    if &filetype =~# 'markdown' && line('$') > 1 && &syntax != 'OFF'
         call s:MarkdownHighlightSources(a:force)
     endif
 endfunction


### PR DESCRIPTION
When &syntax's value is OFF, vim doesn't load syntax files for the file. However, this plugin loads code block syntax highlighting rules even if the value is OFF. This behavior is inconsistent for users to disable syntax highlighting locally. For example, this causes on a modeline such as `<!-- vim: set syntax=OFF -->`.

Use != to compare &syntax's value to use the same logic run on $VIMRUNTIME/syntax/synload.vim.