### PR TITLE
Apply **strong** / *emphasis* syntax for right after punctuations

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -52,12 +52,12 @@ endif
 syntax region mkdItalic matchgroup=mkdItalic start="\%(\*\|_\)"    end="\%(\*\|_\)"
 syntax region mkdBold matchgroup=mkdBold start="\%(\*\*\|__\)"    end="\%(\*\*\|__\)"
 syntax region mkdBoldItalic matchgroup=mkdBoldItalic start="\%(\*\*\*\|___\)"    end="\%(\*\*\*\|___\)"
-execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:],.!?"''''#$%&+\-/:;^|~<>=@()[\]{}　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syntax region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -52,12 +52,12 @@ endif
 syntax region mkdItalic matchgroup=mkdItalic start="\%(\*\|_\)"    end="\%(\*\|_\)"
 syntax region mkdBold matchgroup=mkdBold start="\%(\*\*\|__\)"    end="\%(\*\*\|__\)"
 syntax region mkdBoldItalic matchgroup=mkdBoldItalic start="\%(\*\*\*\|___\)"    end="\%(\*\*\*\|___\)"
-execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|\s\)\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|\s\)\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|\s\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|\s\)\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlItalic matchgroup=mkdItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBold matchgroup=mkdBold start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syntax region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|[[:space:][:punct:]　、。（）「」『』［］【】〚〛｛｝〈〉《》‹›«»〔〕〘〙‘’❛❜“”❝❞]\)\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syntax region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"


### PR DESCRIPTION
For **strong** and *emphasis* syntax,
now it requires line beginning or some space before them.

```
**strong** aaa **strong**
*emphasis* aaa *emphasis*
```

Besides these, allow it is placed right after punctuations.

```
aaa (**strong**)
aaa (*emphasis*)

aaa,**strong**
aaa,*emphasis*

あああ （**最強調**）       # Wide (Japanese) paren
あああ （*強調*）

あああ、**最強調**
あああ、*強調*

あああ　**最強調**          # Wide (Japanese) space
あああ　*強調*
```

Especially, in Japanese, space is rarely used between words.
It is preferred to apply these syntax right after `、` or `。` (Japanese comma, period), even without any space.
