### PR TITLE
Refactor `s:EditUrlUnderCursor()`, and add tests for `ge` when not on a markdown link

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -664,8 +664,10 @@ endfunction
 " script while this function is running. We must not replace it.
 if !exists('*s:EditUrlUnderCursor')
     function s:EditUrlUnderCursor()
-        let l:editmethod = ''
+        let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
+
         " determine how to open the linked file (split, tab, etc)
+        let l:editmethod = ''
         if exists('g:vim_markdown_edit_url_in')
           if g:vim_markdown_edit_url_in ==# 'tab'
             let l:editmethod = 'tabnew'
@@ -680,7 +682,6 @@ if !exists('*s:EditUrlUnderCursor')
           " default to current buffer
           let l:editmethod = 'edit'
         endif
-        let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
 
         " fallback if cursor is not on a markdown link
         if l:url ==# ''
@@ -691,6 +692,8 @@ if !exists('*s:EditUrlUnderCursor')
         if get(g:, 'vim_markdown_autowrite', 0)
             write
         endif
+
+        " parse anchor
         let l:anchor = ''
         if get(g:, 'vim_markdown_follow_anchor', 0)
             let l:parts = split(l:url, '#', 1)
@@ -705,6 +708,7 @@ if !exists('*s:EditUrlUnderCursor')
             endif
         endif
 
+        " add file extension
         let l:ext = ''
         if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
             " use another file extension if preferred
@@ -715,8 +719,8 @@ if !exists('*s:EditUrlUnderCursor')
             endif
         endif
         let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
-        execute l:editmethod l:url
 
+        execute l:editmethod l:url
         if l:anchor !=# ''
             silent! execute '/'.l:anchor
         endif

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -704,19 +704,19 @@ if !exists('*s:EditUrlUnderCursor')
                 endif
             endif
         endif
-        if l:url !=# ''
-            let l:ext = ''
-            if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
-                " use another file extension if preferred
-                if exists('g:vim_markdown_auto_extension_ext')
-                    let l:ext = '.'.g:vim_markdown_auto_extension_ext
-                else
-                    let l:ext = '.md'
-                endif
+
+        let l:ext = ''
+        if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
+            " use another file extension if preferred
+            if exists('g:vim_markdown_auto_extension_ext')
+                let l:ext = '.'.g:vim_markdown_auto_extension_ext
+            else
+                let l:ext = '.md'
             endif
-            let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
-            execute l:editmethod l:url
         endif
+        let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
+        execute l:editmethod l:url
+
         if l:anchor !=# ''
             silent! execute '/'.l:anchor
         endif

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -681,41 +681,44 @@ if !exists('*s:EditUrlUnderCursor')
           let l:editmethod = 'edit'
         endif
         let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
-        if l:url !=# ''
-            if get(g:, 'vim_markdown_autowrite', 0)
-                write
-            endif
-            let l:anchor = ''
-            if get(g:, 'vim_markdown_follow_anchor', 0)
-                let l:parts = split(l:url, '#', 1)
-                if len(l:parts) == 2
-                    let [l:url, l:anchor] = parts
-                    let l:anchorexpr = get(g:, 'vim_markdown_anchorexpr', '')
-                    if l:anchorexpr !=# ''
-                        let l:anchor = eval(substitute(
-                            \ l:anchorexpr, 'v:anchor',
-                            \ escape('"'.l:anchor.'"', '"'), ''))
-                    endif
-                endif
-            endif
-            if l:url !=# ''
-                let l:ext = ''
-                if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
-                    " use another file extension if preferred
-                    if exists('g:vim_markdown_auto_extension_ext')
-                        let l:ext = '.'.g:vim_markdown_auto_extension_ext
-                    else
-                        let l:ext = '.md'
-                    endif
-                endif
-                let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
-                execute l:editmethod l:url
-            endif
-            if l:anchor !=# ''
-                silent! execute '/'.l:anchor
-            endif
-        else
+
+        " fallback if cursor is not on a markdown link
+        if l:url ==# ''
             execute l:editmethod . ' <cfile>'
+            return
+        endif
+
+        if get(g:, 'vim_markdown_autowrite', 0)
+            write
+        endif
+        let l:anchor = ''
+        if get(g:, 'vim_markdown_follow_anchor', 0)
+            let l:parts = split(l:url, '#', 1)
+            if len(l:parts) == 2
+                let [l:url, l:anchor] = parts
+                let l:anchorexpr = get(g:, 'vim_markdown_anchorexpr', '')
+                if l:anchorexpr !=# ''
+                    let l:anchor = eval(substitute(
+                        \ l:anchorexpr, 'v:anchor',
+                        \ escape('"'.l:anchor.'"', '"'), ''))
+                endif
+            endif
+        endif
+        if l:url !=# ''
+            let l:ext = ''
+            if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
+                " use another file extension if preferred
+                if exists('g:vim_markdown_auto_extension_ext')
+                    let l:ext = '.'.g:vim_markdown_auto_extension_ext
+                else
+                    let l:ext = '.md'
+                endif
+            endif
+            let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
+            execute l:editmethod l:url
+        endif
+        if l:anchor !=# ''
+            silent! execute '/'.l:anchor
         endif
     endfunction
 endif

--- a/test/map.vader
+++ b/test/map.vader
@@ -90,6 +90,41 @@ Execute (ge auto-write before opening file):
   unlet g:vim_markdown_autowrite
 
 Given markdown;
+ge_test.md
+
+Execute (ge falls back to edit <cfile> when not on a markdown link):
+  normal ge
+  AssertEqual @%, 'ge_test.md'
+  AssertEqual getline(1), 'ge test'
+
+Given markdown;
+
+Execute (ge falls back to edit <cfile> which throws if cursor is not on a link):
+  " TODO: Fix this to be consistent with gx
+  AssertThrows normal ge
+  AssertEqual g:vader_exception, 'Vim(edit):E446: No file name under cursor'
+
+Given markdown;
+ge_test
+
+Execute (ge fallback does not respect g:vim_markdown_no_extensions_in_markdown):
+  let g:vim_markdown_no_extensions_in_markdown = 1
+  normal ge
+  AssertEqual @%, 'ge_test'
+  unlet g:vim_markdown_no_extensions_in_markdown
+
+Given markdown;
+ge_test.md
+
+Execute (ge fallback does not respect g:vim_markdown_autowrite):
+  " TODO: Fix this
+  let g:vim_markdown_autowrite = 1
+  normal ia
+  normal l
+  normal ge " this would throw if file write was attempted
+  unlet g:vim_markdown_autowrite
+
+Given markdown;
 # a
 
 b


### PR DESCRIPTION
This does not affect behaviour of `ge`. Some things to fix are marked TODO in the tests, however how to approach this depends on dicussion in #482 .