### PR TITLE
Add extensive syntax(bold, italic & bolditalic) highlight support

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -51,15 +51,13 @@ if get(g:, 'vim_markdown_emphasis_multiline', 1)
 else
     let s:oneline = ' oneline'
 endif
-syn region mkdItalic matchgroup=mkdItalic start="\%(\*\|_\)"    end="\%(\*\|_\)"
-syn region mkdBold matchgroup=mkdBold start="\%(\*\*\|__\)"    end="\%(\*\*\|__\)"
-syn region mkdBoldItalic matchgroup=mkdBoldItalic start="\%(\*\*\*\|___\)"    end="\%(\*\*\*\|___\)"
-execute 'syn region htmlItalic matchgroup=mkdItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\%(\%([^*]\|\\\*\|\n\)*[^\\\*\t ]\)\?\*\_W" end="[^\\\*\t ]\zs\*\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syn region htmlItalic matchgroup=mkdItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syn region htmlBold matchgroup=mkdBold start="\%(^\|\s\)\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syn region htmlBold matchgroup=mkdBold start="\%(^\|\s\)\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syn region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|\s\)\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
-execute 'syn region htmlBoldItalic matchgroup=mkdBoldItalic start="\%(^\|\s\)\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
+
+execute 'syn region htmlItalic matchgroup=mkdItalic start="\(\\\|\*\)\@<!\zs\*\ze\S" end="\S\zs\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syn region htmlItalic matchgroup=mkdItalic start="\(\\\|_\)\@<!\zs_\ze\S" end="\S\zs_" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syn region htmlBold matchgroup=mkdBold start="\(\\\|\*\)\@<!\zs\*\*\ze\S" end="\S\zs\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syn region htmlBold matchgroup=mkdBold start="\(\\\|_\)\@<!\zs__\ze\S" end="\S\zs__" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syn region htmlBoldItalic matchgroup=mkdBoldItalic start="\(\\\|\*\)\@<!\zs\*\*\*\ze\S" end="\S\zs\*\*\*" keepend contains=@Spell' . s:oneline . s:concealends
+execute 'syn region htmlBoldItalic matchgroup=mkdBoldItalic start="\(\\\|_\)\@<!\zs___\ze\S" end="\S\zs___" keepend contains=@Spell' . s:oneline . s:concealends
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"


### PR DESCRIPTION
This pr related to 

- #164 
- #387 
- #587 

I'm a vim-new-leaner so that I don't confirm if this fix has bugs. But I've tried my best.

Here's the test code

<details><summary>Markdown Test Code</summary>

````markdown
aaa **a** aaaaaa **a** aaa

aaa **a**aaaaaa **a**aaa

aaa**a** aaaaaa**a** aaa

aaa**a**aaaaaa**a**aaa

我 **你** 他我 **你** 他

我 **你**他我 **你**他

我**你** 他我**你** 他

我**你**他我**你**他 $aa**aa**$

aaa**a**aa

\**aa

$**$ aaa

**a

b**

aaa *a* aaaaaa *a* aaa

aaa *a*aaaaaa *a*aaa

aaa*a* aaaaaa*a* aaa

aaa*a*aaaaaa*a*aaa

我 *你* 他我 *你* 他

我 *你*他我 *你*他

我*你* 他我*你* 他

我*你*他我*你*他 $aa*aa*$

aaa*a*aa

\*aa

$*$ aaa

*a

b*

aaa ***a*** aaaaaa ***a*** aaa

aaa ***a***aaaaaa ***a***aaa

aaa***a*** aaaaaa***a*** aaa

aaa***a***aaaaaa***a***aaa

我 ***你*** 他我 ***你*** 他

我 ***你***他我 ***你***他

我***你*** 他我***你*** 他

我***你***他我***你***他 $aa***aa***$

aaa***a***aa

\***aa

$***$ aaa

***a

b***

```
aa***aa***
```

aa
````

</details>

![Snipaste_2022-06-11_17-12-42](https://user-images.githubusercontent.com/80107081/173181671-a52370f4-c015-4e66-82ef-8b6e47eafe1c.png)

![Snipaste_2022-06-11_17-13-00](https://user-images.githubusercontent.com/80107081/173181673-996d0ecf-7539-401b-ac4d-d7c8a29b391b.png)

![Snipaste_2022-06-11_17-13-08](https://user-images.githubusercontent.com/80107081/173181674-d43d21c0-4cb9-44ec-a503-ad2857740c9d.png)

Every suggestion is welcome!