### PR TITLE
Table align with colons

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -546,7 +546,23 @@ function! s:TableFormat()
     let l:flags = (&gdefault ? '' : 'g')
     execute 's/\(:\@<!-:\@!\|[^|:-]\)//e' . l:flags
     execute 's/--/-/e' . l:flags
-    Tabularize /|
+    if get(g:, 'vim_markdown_table_align_with_colons', 1)
+        let l:align = 'c0'
+        for l:line in split(getbufline(bufname(), line('.'))[0], '|', 1)[1:-2]
+            let l:align .= 'c1'
+            if l:line ==# '-:'
+                let l:align .= 'r1'
+            elseif l:line ==# ':-:'
+                let l:align .= 'c1'
+            else
+                let l:align .= 'l1'
+            endif
+        endfor
+        let l:align .= 'c0'
+        execute 'Tabularize /|/' . l:align
+    else
+        Tabularize /|
+    endif 
     " Move colons for alignment to left or right side of the cell.
     execute 's/:\( \+\)|/\1:|/e' . l:flags
     execute 's/|\( \+\):/|:\1/e' . l:flags

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -69,16 +69,16 @@ Expect (preserve colons to align text):
     |:-----|------:|:------:|:--|
     | left | right | center |   |
 
-Given markdown (indented table with colons and multiple rows);
-  | left |extra right|  c  |left|
-  | :- | --: |:---:|:|
-  | left more |right|  center | l |
+Given markdown (table with colons and rows containing text of different length);
+| left |extra right|  c  |left|
+| :- | --: |:---:|:|
+| left more |right|  center | l |
 
-Execute (format indented table with colons and multiple rows):
+Execute (format table with colons and rows containing text of different length):
   TableFormat
 
 Expect (align text in accordance with the colons):
-    | left      | extra right |    c   | left |
-    |:----------|------------:|:------:|:-----|
-    | left more |       right | center | l    |
+  | left      | extra right |    c   | left |
+  |:----------|------------:|:------:|:-----|
+  | left more |       right | center | l    |
 

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -68,3 +68,17 @@ Expect (preserve colons to align text):
     | left | right | center |   |
     |:-----|------:|:------:|:--|
     | left | right | center |   |
+
+Given markdown (indented table with colons and multiple rows);
+  | left |extra right|  c  |left|
+  | :- | --: |:---:|:|
+  | left more |right|  center | l |
+
+Execute (format indented table with colons and multiple rows):
+  TableFormat
+
+Expect (align text in accordance with the colons):
+    | left      | extra right |    c   | left |
+    |:----------|------------:|:------:|:-----|
+    | left more |       right | center | l    |
+


### PR DESCRIPTION
Align table columns in accordance with colons. by providing Tabularize command format specifier matching the colons