### PR TITLE
Remove outdated advice for Vim plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,6 @@ The following options control which syntax extensions will be turned on. They ar
 
     Highlight TOML front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
 
-    TOML syntax highlight requires [vim-toml](https://github.com/cespare/vim-toml).
-
         let g:vim_markdown_toml_frontmatter = 1
 
 #### JSON Front Matter
@@ -271,8 +269,6 @@ The following options control which syntax extensions will be turned on. They ar
 -   `g:vim_markdown_json_frontmatter`
 
     Highlight JSON front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
-
-    JSON syntax highlight requires [vim-json](https://github.com/elzr/vim-json).
 
         let g:vim_markdown_json_frontmatter = 1
 


### PR DESCRIPTION
The only reason you would need to use vim-toml or vim-json is if you use an old version of (Neo)Vim. As of today, you do not need those plugins.