### PR TITLE
Remove all mentions of vim-json and vim-toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,25 +20,17 @@ install:
 	mkdir -pv ${REGISTRY}
 	cp -v registry/markdown.yaml ${REGISTRY}/markdown.yaml
 
-test: build/tabular build/vim-toml build/vim-json build/vader.vim
+test: build/tabular build/vader.vim
 	test/run-tests.sh
 .PHONY: test
 
-update: build/tabular build/vim-toml build/vim-json build/vader.vim
+update: build/tabular build/vader.vim
 	cd build/tabular && git pull
-	cd build/vim-toml && git pull
-	cd build/vim-json && git pull
 	cd build/vader.vim && git pull
 .PHONY: update
 
 build/tabular: | build
 	git clone https://github.com/godlygeek/tabular build/tabular
-
-build/vim-toml: | build
-	git clone https://github.com/cespare/vim-toml build/vim-toml
-
-build/vim-json: | build
-	git clone https://github.com/elzr/vim-json build/vim-json
 
 build/vader.vim: | build
 	git clone https://github.com/junegunn/vader.vim build/vader.vim

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -360,8 +360,6 @@ TOML Front Matter ~
 - 'g:vim_markdown_toml_frontmatter'
 
   Highlight TOML front matter as used by Hugo [7].
-
-  TOML syntax highlight requires vim-toml [8].
 >
   let g:vim_markdown_toml_frontmatter = 1
 <
@@ -373,8 +371,6 @@ JSON Front Matter ~
 - 'g:vim_markdown_json_frontmatter'
 
   Highlight JSON front matter as used by Hugo [7].
-
-  JSON syntax highlight requires vim-json [9].
 >
   let g:vim_markdown_json_frontmatter = 1
 <
@@ -581,9 +577,9 @@ The following requires ':filetype plugin on'.
   range.
 
                                                                  *:TableFormat*
-- ':TableFormat': Format the table under the cursor like this [10].
+- ':TableFormat': Format the table under the cursor like this [8].
 
-  Requires Tabular [11].
+  Requires Tabular [9].
 
   The input table _must_ already have a separator line as the second line of
   the table. That line only needs to contain the correct pipes '|', nothing
@@ -612,7 +608,7 @@ Credits ~
 The main contributors of vim-markdown are:
 
 - **Ben Williams** (A.K.A. **plasticboy**). The original developer of vim-
-  markdown. Homepage [12].
+  markdown. Homepage [10].
 
 If you feel that your name should be on this list, please make a pull request
 listing your contributions.
@@ -654,10 +650,8 @@ References ~
 [5] https://github.com/preservim/vim-markdown/archive/master.tar.gz
 [6] https://github.com/klen/python-mode
 [7] https://gohugo.io/content/front-matter/
-[8] https://github.com/cespare/vim-toml
-[9] https://github.com/elzr/vim-json
-[10] http://www.cirosantilli.com/markdown-style-guide/#tables
-[11] https://github.com/godlygeek/tabular
-[12] http://plasticboy.com/
+[8] http://www.cirosantilli.com/markdown-style-guide/#tables
+[9] https://github.com/godlygeek/tabular
+[10] http://plasticboy.com/
 
 vim: ft=help

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5,7 +5,7 @@ set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-for dep in ../build/tabular ../build/vim-toml ../build/vim-json ../build/vader.vim; do
+for dep in ../build/tabular ../build/vader.vim; do
   if [[ ! -d $dep ]]; then
     echo "Missing dependency: $dep"
     echo "You may just want to use 'make test'."

--- a/test/vimrc
+++ b/test/vimrc
@@ -5,8 +5,6 @@ let $LANG='en_US'
 filetype off
 set runtimepath+=../
 set runtimepath+=../build/tabular/
-set runtimepath+=../build/vim-toml/
-set runtimepath+=../build/vim-json/
 set runtimepath+=../build/vader.vim/
 filetype on
 


### PR DESCRIPTION
Since vim-json and vim-toml are not needed in Vim or Neovim anymore, I removed all mentions of them in any file. It didn't allow me to push changes of `.github/workflows/vader.yml`.