### PR TITLE
`:Toc` does not work with other quickfix list plugins

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -405,14 +405,6 @@ function! s:Toc(...)
     else
         lopen
     endif
-    setlocal modifiable
-    for i in range(1, line('$'))
-        " this is the location-list data for the current item
-        let d = getloclist(0)[i-1]
-        call setline(i, d.text)
-    endfor
-    setlocal nomodified
-    setlocal nomodifiable
     execute 'normal! ' . l:cursor_header . 'G'
 endfunction
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -192,11 +192,6 @@ function! s:GetHeaderList()
             let l:is_header = 0
         endif
         if l:is_header ==# 1 && l:fenced_block ==# 0 && l:front_matter ==# 0
-            " remove hashes from atx headers
-            if match(l:line, '^#') > -1
-                let l:line = substitute(l:line, '\v^#*[ ]*', '', '')
-                let l:line = substitute(l:line, '\v[ ]*#*$', '', '')
-            endif
             " append line to list
             let l:level = s:GetHeaderLevel(i)
             let l:item = {'level': l:level, 'text': l:line, 'lnum': i, 'bufnr': bufnr}


### PR DESCRIPTION
`:Toc` does not work with other quickfix list plugins such as [`itchyny/vim-qfedit`](https://github.com/itchyny/vim-qfedit):
it checks location list line validity, so `vim-markdown`'s modified TOC lines are dropped.

So dropped TOC location list modifications.
