### PR TITLE
Fenced code highlight in liquid

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -854,19 +854,23 @@ function! s:SyntaxInclude(filetype)
     return grouplistname
 endfunction
 
+function! s:IsHighlightSourcesEnabledForBuffer()
+    " Enable for markdown buffers, and for liquid buffers with markdown format
+    return &filetype =~# 'markdown' || get(b:, 'liquid_subtype', '') =~# 'markdown'
+endfunction
 
 function! s:MarkdownRefreshSyntax(force)
     " Use != to compare &syntax's value to use the same logic run on
     " $VIMRUNTIME/syntax/synload.vim.
     "
     " vint: next-line -ProhibitEqualTildeOperator
-    if &filetype =~# 'markdown' && line('$') > 1 && &syntax != 'OFF'
+    if s:IsHighlightSourcesEnabledForBuffer() && line('$') > 1 && &syntax != 'OFF'
         call s:MarkdownHighlightSources(a:force)
     endif
 endfunction
 
 function! s:MarkdownClearSyntaxVariables()
-    if &filetype =~# 'markdown'
+    if s:IsHighlightSourcesEnabledForBuffer()
         unlet! b:mkd_included_filetypes
     endif
 endfunction

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -2,6 +2,7 @@ Before:
   unlet! b:mkd_known_filetypes
   unlet! b:mkd_included_filetypes
   unlet! g:vim_markdown_math
+  unlet! b:liquid_subtype
 
 Given markdown;
 a **b** c
@@ -854,6 +855,17 @@ a
 
 Execute (fenced code block with extended info strings):
   AssertEqual SyntaxOf('a'), 'mkdCode'
+
+Given liquid;
+```vim
+let g:a = 1
+```
+
+Execute (fenced code block syntax in liquid file with markdown subtype):
+  let b:liquid_subtype = 'markdown'
+  let b:func = Markdown_GetFunc('vim-markdown/ftplugin/markdown.vim', 'MarkdownRefreshSyntax')
+  call b:func(0)
+  AssertEqual SyntaxOf('g:a'), 'vimVar'
 
 # Code Blocks in pre and code tag
 


### PR DESCRIPTION
Allow fenced code block syntax highlighting to work in liquid buffers that have markdown subtype. This provides compatibility with vim-liquid.

Resolves #608 