### PR TITLE
modify `s:headersRegexp`  in ftplugin/markdown.vim

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -61,7 +61,7 @@ let s:levelRegexpDict = {
 " This could be deduced from `s:levelRegexpDict`, but it is more
 " efficient to have a single regexp for this.
 "
-let s:headersRegexp = '\v^(#|.+\n(\=+|-+)$)'
+let s:headersRegexp = '\v^(#{1,6}\s|.+\n(\=+|-+)$)'
 
 " Returns the line number of the first header before `line`, called the
 " current header.


### PR DESCRIPTION
I modify this variable because the former will mistake a hashtag for a title in `:Toc`

**Before** this commit:

![image](https://github.com/preservim/vim-markdown/assets/40995042/dfa9c6fb-a8e6-4469-839a-bbde2bd8bd70)

**After** this commit:

![60 QYSD4J{ QG85Q9Y%}_9](https://github.com/preservim/vim-markdown/assets/40995042/e7e0a988-f905-4c40-abcb-fc892a6969e4)
