### PR TITLE
Code fence handling breaks if `~~~` appears in the fence

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -14,15 +14,21 @@ endfunction
 
 if get(g:, 'vim_markdown_folding_style_pythonic', 0)
     function! Foldexpr_markdown(lnum)
+        if (a:lnum == 1)
+            let b:fence_str = ''
+        endif
+
         let l1 = getline(a:lnum)
         "~~~~~ keep track of fenced code blocks ~~~~~
         "If we hit a code block fence
-        if l1 =~# '````*' || l1 =~# '\~\~\~\~*'
+        if l1 =~# '\v^[[:space:]>]*\v(`{3,}|\~{3,})\s*(\w+)?\s*$'
             " toggle the variable that says if we're in a code block
             if b:fenced_block == 0
                 let b:fenced_block = 1
-            elseif b:fenced_block == 1
+                let b:fence_str = matchstr(l1, '\v(`{3,}|\~{3,})')
+            elseif b:fenced_block == 1 && matchstr(l1, '\v(`{3,}|\~{3,})') ==# b:fence_str
                 let b:fenced_block = 0
+                let b:fence_str = ''
             endif
         " else, if we're caring about front matter
         elseif get(g:, 'vim_markdown_frontmatter', 0) == 1
@@ -100,16 +106,19 @@ else " vim_markdown_folding_style_pythonic == 0
     function! Foldexpr_markdown(lnum)
         if (a:lnum == 1)
             let l0 = ''
+            let b:fence_str = ''
         else
             let l0 = getline(a:lnum-1)
         endif
 
         " keep track of fenced code blocks
-        if l0 =~# '````*' || l0 =~# '\~\~\~\~*'
+        if l0 =~# '\v^[[:space:]>]*\v(`{3,}|\~{3,})\s*(\w+)?\s*$'
             if b:fenced_block == 0
                 let b:fenced_block = 1
-            elseif b:fenced_block == 1
+                let b:fence_str = matchstr(l0, '\v(`{3,}|\~{3,})')
+            elseif b:fenced_block == 1 && matchstr(l0, '\v(`{3,}|\~{3,})') ==# b:fence_str
                 let b:fenced_block = 0
+                let b:fence_str = ''
             endif
         elseif get(g:, 'vim_markdown_frontmatter', 0) == 1
             if b:front_matter == 1

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -162,16 +162,19 @@ function! s:GetHeaderList()
     let l:front_matter = 0
     let l:header_list = []
     let l:vim_markdown_frontmatter = get(g:, 'vim_markdown_frontmatter', 0)
+    let l:fence_str = ''
     for i in range(1, line('$'))
         let l:lineraw = getline(i)
         let l:l1 = getline(i+1)
         let l:line = substitute(l:lineraw, '#', "\\\#", 'g')
         " exclude lines in fenced code blocks
-        if l:line =~# '````*' || l:line =~# '\~\~\~\~*'
+        if l:line =~# '\v^[[:space:]>]*(`{3,}|\~{3,})\s*(\w+)?\s*$'
             if l:fenced_block == 0
                 let l:fenced_block = 1
-            elseif l:fenced_block == 1
+                let l:fence_str = matchstr(l:line, '\v(`{3,}|\~{3,})')
+            elseif l:fenced_block == 1 && matchstr(l:line, '\v(`{3,}|\~{3,})') ==# l:fence_str
                 let l:fenced_block = 0
+                let l:fence_str = ''
             endif
         " exclude lines in frontmatters
         elseif l:vim_markdown_frontmatter == 1


### PR DESCRIPTION
Text like below will break code fence.

~~~text
# Heading 1

## Heading 1-1

```text
~~~hoge~~~
```

# Heading 2

## Heading 2-1

```
~~~piyo~~~
```

# Heading 3

## Heading 3-1

```text
hogefugapiyo
    ~~~~
```

# Heading 4

## Heading 4-1
~~~

Fixed the check pattern, and fence ending check to compare with the fence beginning string.

`:Toc` command and text folding do work.

Can anyone fix syntax `syntax/markdown.vim`?
