### PR TITLE
Add syntax highlighting to some elements inside headings

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -156,7 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdLink,mkdInlineURL
+syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdInlineURL
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -156,7 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdInlineURL
+syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdInlineURL,mkdStrike
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -156,7 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdHeadingContent contains=htmlItalic,mkdLink,mkdInlineURL
+syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,mkdLink,mkdInlineURL
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -86,14 +86,14 @@ syn region mkdLinkTitle matchgroup=mkdDelimiter start=+'+     end=+'+  contained
 syn region mkdLinkTitle matchgroup=mkdDelimiter start=+(+     end=+)+  contained
 
 "HTML headings
-syn region htmlH1       matchgroup=mkdHeading     start="^\s*#"                   end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH2       matchgroup=mkdHeading     start="^\s*##"                  end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH3       matchgroup=mkdHeading     start="^\s*###"                 end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH4       matchgroup=mkdHeading     start="^\s*####"                end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH5       matchgroup=mkdHeading     start="^\s*#####"               end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH6       matchgroup=mkdHeading     start="^\s*######"              end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn match  htmlH1       /^.\+\n=\+$/ contains=mkdLink,mkdInlineURL,@Spell
-syn match  htmlH2       /^.\+\n-\+$/ contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH1       matchgroup=mkdHeading     start="^\s*#"                   end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH2       matchgroup=mkdHeading     start="^\s*##"                  end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH3       matchgroup=mkdHeading     start="^\s*###"                 end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH4       matchgroup=mkdHeading     start="^\s*####"                end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH5       matchgroup=mkdHeading     start="^\s*#####"               end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH6       matchgroup=mkdHeading     start="^\s*######"              end="$" contains=@mkdHeadingContent,@Spell
+syn match  htmlH1       /^.\+\n=\+$/ contains=@mkdHeadingContent,@Spell
+syn match  htmlH2       /^.\+\n-\+$/ contains=@mkdHeadingContent,@Spell
 
 "define Markdown groups
 syn match  mkdLineBreak    /  \+$/
@@ -156,6 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
+syn cluster mkdHeadingContent contains=htmlItalic,mkdLink,mkdInlineURL
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -156,7 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,mkdLink,mkdInlineURL
+syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdLink,mkdInlineURL
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups

--- a/test/strikethrough.vader
+++ b/test/strikethrough.vader
@@ -1,0 +1,41 @@
+Before:
+  let g:vim_markdown_strikethrough = 1
+  syn off | syn on
+
+After:
+  unlet! g:vim_markdown_strikethrough
+
+Given markdown;
+a ~~b~~ c
+
+Execute (strikethrough):
+  AssertNotEqual SyntaxOf('a'), 'mkdStrike'
+  AssertEqual SyntaxOf('b'), 'mkdStrike'
+  AssertNotEqual SyntaxOf('c'), 'mkdStrike'
+
+Given markdown;
+# ~~h1~~
+## ~~h2~~
+### ~~h3~~
+#### ~~h4~~
+##### ~~h5~~
+###### ~~h6~~
+
+Execute (strikethrough in atx headings):
+  AssertEqual SyntaxOf('h1'), 'mkdStrike'
+  AssertEqual SyntaxOf('h2'), 'mkdStrike'
+  AssertEqual SyntaxOf('h3'), 'mkdStrike'
+  AssertEqual SyntaxOf('h4'), 'mkdStrike'
+  AssertEqual SyntaxOf('h5'), 'mkdStrike'
+  AssertEqual SyntaxOf('h6'), 'mkdStrike'
+
+Given markdown;
+~~h1~~
+=
+
+~~h2~~
+-
+
+Execute (strikethrough in setext headings):
+  AssertEqual SyntaxOf('h1'), 'mkdStrike'
+  AssertEqual SyntaxOf('h2'), 'mkdStrike'

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1430,3 +1430,67 @@ Given markdown;
 Execute (asterisk bold text in setext headings):
   AssertEqual SyntaxOf('h1'), 'htmlBold'
   AssertEqual SyntaxOf('h2'), 'htmlBold'
+
+Given markdown;
+# ___h1___
+
+## ___h2___
+
+### ___h3___
+
+#### ___h4___
+
+##### ___h5___
+
+###### ___h6___
+
+Execute (underscore bold italic text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h3'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h4'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h5'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h6'), 'htmlBoldItalic'
+
+Given markdown;
+# ***h1***
+
+## ***h2***
+
+### ***h3***
+
+#### ***h4***
+
+##### ***h5***
+
+###### ***h6***
+
+Execute (asterisk bold italic text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h3'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h4'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h5'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h6'), 'htmlBoldItalic'
+
+Given markdown;
+___h1___
+=
+
+___h2___
+-
+
+Execute (underscore bold italic text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlBoldItalic'
+
+Given markdown;
+***h1***
+=
+
+***h2***
+-
+
+Execute (asterisk bold italic text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBoldItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlBoldItalic'

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1366,3 +1366,67 @@ Given markdown;
 Execute (asterisk italic text in setext headings):
   AssertEqual SyntaxOf('h1'), 'htmlItalic'
   AssertEqual SyntaxOf('h2'), 'htmlItalic'
+
+Given markdown;
+# __h1__
+
+## __h2__
+
+### __h3__
+
+#### __h4__
+
+##### __h5__
+
+###### __h6__
+
+Execute (underscore bold text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBold'
+  AssertEqual SyntaxOf('h2'), 'htmlBold'
+  AssertEqual SyntaxOf('h3'), 'htmlBold'
+  AssertEqual SyntaxOf('h4'), 'htmlBold'
+  AssertEqual SyntaxOf('h5'), 'htmlBold'
+  AssertEqual SyntaxOf('h6'), 'htmlBold'
+
+Given markdown;
+# **h1**
+
+## **h2**
+
+### **h3**
+
+#### **h4**
+
+##### **h5**
+
+###### **h6**
+
+Execute (asterisk bold text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBold'
+  AssertEqual SyntaxOf('h2'), 'htmlBold'
+  AssertEqual SyntaxOf('h3'), 'htmlBold'
+  AssertEqual SyntaxOf('h4'), 'htmlBold'
+  AssertEqual SyntaxOf('h5'), 'htmlBold'
+  AssertEqual SyntaxOf('h6'), 'htmlBold'
+
+Given markdown;
+__h1__
+=
+
+__h2__
+-
+
+Execute (underscore bold text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBold'
+  AssertEqual SyntaxOf('h2'), 'htmlBold'
+
+Given markdown;
+**h1**
+=
+
+**h2**
+-
+
+Execute (asterisk bold text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlBold'
+  AssertEqual SyntaxOf('h2'), 'htmlBold'

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1302,3 +1302,67 @@ Execute (HTML tag in text):
   AssertEqual SyntaxOf('span'), 'htmlTagName'
   AssertEqual SyntaxOf('<span>'), 'htmlTag'
   AssertEqual SyntaxOf('</span>'), 'htmlEndTag'
+
+Given markdown;
+# _h1_
+
+## _h2_
+
+### _h3_
+
+#### _h4_
+
+##### _h5_
+
+###### _h6_
+
+Execute (underscore italic text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlItalic'
+  AssertEqual SyntaxOf('h3'), 'htmlItalic'
+  AssertEqual SyntaxOf('h4'), 'htmlItalic'
+  AssertEqual SyntaxOf('h5'), 'htmlItalic'
+  AssertEqual SyntaxOf('h6'), 'htmlItalic'
+
+Given markdown;
+# *h1*
+
+## *h2*
+
+### *h3*
+
+#### *h4*
+
+##### *h5*
+
+###### *h6*
+
+Execute (asterisk italic text in atx headings):
+  AssertEqual SyntaxOf('h1'), 'htmlItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlItalic'
+  AssertEqual SyntaxOf('h3'), 'htmlItalic'
+  AssertEqual SyntaxOf('h4'), 'htmlItalic'
+  AssertEqual SyntaxOf('h5'), 'htmlItalic'
+  AssertEqual SyntaxOf('h6'), 'htmlItalic'
+
+Given markdown;
+_h1_
+=
+
+_h2_
+-
+
+Execute (underscore italic text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlItalic'
+
+Given markdown;
+*h1*
+=
+
+*h2*
+-
+
+Execute (asterisk italic text in setext headings):
+  AssertEqual SyntaxOf('h1'), 'htmlItalic'
+  AssertEqual SyntaxOf('h2'), 'htmlItalic'

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1494,3 +1494,35 @@ Given markdown;
 Execute (asterisk bold italic text in setext headings):
   AssertEqual SyntaxOf('h1'), 'htmlBoldItalic'
   AssertEqual SyntaxOf('h2'), 'htmlBoldItalic'
+
+Given markdown;
+# [^h1]
+
+## [^h2]
+
+### [^h3]
+
+#### [^h4]
+
+##### [^h5]
+
+###### [^h6]
+
+Execute (footnotes in atx headings):
+  AssertEqual SyntaxOf('h1'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h2'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h3'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h4'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h5'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h6'), 'mkdFootnotes'
+
+Given markdown;
+[^h1]
+=
+
+[^h2]
+-
+
+Execute (footnotes in setext headings):
+  AssertEqual SyntaxOf('h1'), 'mkdFootnotes'
+  AssertEqual SyntaxOf('h2'), 'mkdFootnotes'


### PR DESCRIPTION
Changes

- highlights bold, italic, bold italic, strikethrough and footnotes inside headings.

This should fix #614, but not #635.