### PR TITLE
Todo highlighting in html comments

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -116,6 +116,7 @@ syn region mkdNonListItemBlock start="\(\%^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@!\|\n\(
 syn match  mkdRule         /^\s*\*\s\{0,1}\*\s\{0,1}\*\(\*\|\s\)*$/
 syn match  mkdRule         /^\s*-\s\{0,1}-\s\{0,1}-\(-\|\s\)*$/
 syn match  mkdRule         /^\s*_\s\{0,1}_\s\{0,1}_\(_\|\s\)*$/
+syn keyword mkdTodo TODO FIXME XXX TBD contained containedin=htmlComment,htmlCommentPart
 
 " YAML frontmatter
 if get(g:, 'vim_markdown_frontmatter', 0)
@@ -179,6 +180,7 @@ HtmlHiLink mkdLinkDef          mkdID
 HtmlHiLink mkdLinkDefTarget    mkdURL
 HtmlHiLink mkdLinkTitle        htmlString
 HtmlHiLink mkdDelimiter        Delimiter
+HtmlHiLink mkdTodo             Todo
 
 let b:current_syntax = 'mkd'
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1302,3 +1302,40 @@ Execute (HTML tag in text):
   AssertEqual SyntaxOf('span'), 'htmlTagName'
   AssertEqual SyntaxOf('<span>'), 'htmlTag'
   AssertEqual SyntaxOf('</span>'), 'htmlEndTag'
+
+Given markdown;
+<!--TODO FIXME XXX TBD hello -->
+
+Execute (todo inside HTML comment):
+  AssertEqual SyntaxOf('TODO'), 'mkdTodo'
+  AssertEqual SyntaxOf('FIXME'), 'mkdTodo'
+  AssertEqual SyntaxOf('XXX'), 'mkdTodo'
+  AssertEqual SyntaxOf('TBD'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('hello'), 'mkdTodo'
+
+Given markdown;
+<!--ATODO BFIXME CXXX DTBD -->
+
+Execute (fake todo inside HTML comment):
+  AssertNotEqual SyntaxOf('TODO'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('FIXME'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('XXX'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('TBD'), 'mkdTodo'
+
+Given markdown;
+TODO FIXME XXX TBD
+
+Execute (todo outside HTML comment):
+  AssertNotEqual SyntaxOf('TODO'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('FIXME'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('XXX'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('TBD'), 'mkdTodo'
+
+Given markdown;
+> TODO FIXME XXX TBD
+
+Execute (todo inside non-HTML comment):
+  AssertNotEqual SyntaxOf('TODO'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('FIXME'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('XXX'), 'mkdTodo'
+  AssertNotEqual SyntaxOf('TBD'), 'mkdTodo'


### PR DESCRIPTION
Fixes #369

Highlights TODO, FIXME, XXX and TBD inside html comments.