### PR TITLE
add support for tables without borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,27 @@ The following options control which syntax extensions will be turned on. They ar
 
         let g:vim_markdown_edit_url_in = 'tab'
 
+### Borderless tables
+
+-   `g:vim_markdown_borderless_table`
+
+    Add support for borderless tables, such as:
+    ```
+    header 1|header 2
+    --|--
+    data 1|data 2
+    ```
+    if set to `1`:
+
+        let g:vim_markdown_borderless_table = 1
+
+    the table would be formatted as usual:
+    ```
+    | header 1 | header 2 |
+    |----------|----------|
+    | data 1   | data 2   |
+    ```
+
 ## Mappings
 
 The following work on normal and visual modes:

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -490,6 +490,30 @@ Change how to open new files ~
 >
   let g:vim_markdown_edit_url_in = 'tab'
 <
+-------------------------------------------------------------------------------
+                                    *vim-markdown-support-borderless-tables*
+Support borderless tables ~
+
+                                              *g:vim_markdown_borderless_table*
+- 'g:vim_markdown_borderless_table'
+
+  Add support for borderless tables, such as:
+>
+  header 1|header 2
+  --|--
+  data 1|data 2
+<
+  if set to 1:
+>
+  let g:vim_markdown_borderless_table = 1
+<
+  the table would be formatted as usual:
+>
+  | header 1 | header 2 |
+  |----------|----------|
+  | data 1   | data 2   |
+<
+
 ===============================================================================
                                                         *vim-markdown-mappings*
 Mappings ~

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -774,7 +774,7 @@ endif
 command! -buffer -range=% HeaderDecrease call s:HeaderDecrease(<line1>, <line2>)
 command! -buffer -range=% HeaderIncrease call s:HeaderDecrease(<line1>, <line2>, 1)
 command! -buffer -range=% SetexToAtx call s:SetexToAtx(<line1>, <line2>)
-command! -range TableFormat '<,'> call s:TableFormat()
+command! -buffer -range TableFormat call s:TableFormat()
 command! -buffer Toc call s:Toc()
 command! -buffer Toch call s:Toc('horizontal')
 command! -buffer Tocv call s:Toc('vertical')

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -539,13 +539,17 @@ endfunction
 function! s:TableFormat()
     let l:pos = getpos('.')
 
-    normal! {
-    call search('|')
-    execute 'silent .,''}s/\v^(\s{0,})\|?([^\|])/\1|\2/e'
+    if get(g:, 'vim_markdown_borderless_table', 0)
+      " add `|` to the beginning of the line if it isn't present
+      normal! {
+      call search('|')
+      execute 'silent .,''}s/\v^(\s{0,})\|?([^\|])/\1|\2/e'
 
-    normal! {
-    call search('|')
-    execute 'silent .,''}s/\v([^\|])\|?(\s{0,})$/\1|\2/e'
+      " add `|` to the end of the line if it isn't present
+      normal! {
+      call search('|')
+      execute 'silent .,''}s/\v([^\|])\|?(\s{0,})$/\1|\2/e'
+    endif
 
     normal! {
     " Search instead of `normal! j` because of the table at beginning of file edge case.

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -538,6 +538,15 @@ endfunction
 "
 function! s:TableFormat()
     let l:pos = getpos('.')
+
+    normal! {
+    call search('|')
+    execute 'silent .,''}s/\v^(\s{0,})\|?([^\|])/\1|\2/e'
+
+    normal! {
+    call search('|')
+    execute 'silent .,''}s/\v([^\|])\|?(\s{0,})$/\1|\2/e'
+
     normal! {
     " Search instead of `normal! j` because of the table at beginning of file edge case.
     call search('|')
@@ -765,7 +774,7 @@ endif
 command! -buffer -range=% HeaderDecrease call s:HeaderDecrease(<line1>, <line2>)
 command! -buffer -range=% HeaderIncrease call s:HeaderDecrease(<line1>, <line2>, 1)
 command! -buffer -range=% SetexToAtx call s:SetexToAtx(<line1>, <line2>)
-command! -buffer TableFormat call s:TableFormat()
+command! -range TableFormat '<,'> call s:TableFormat()
 command! -buffer Toc call s:Toc()
 command! -buffer Toch call s:Toc('horizontal')
 command! -buffer Tocv call s:Toc('vertical')

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -77,6 +77,7 @@ Given markdown (borderless table);
 Execute (format borderless table):
   let g:vim_markdown_borderless_table = 1
   TableFormat
+  unlet g:vim_markdown_borderless_table
 
 Expect (table with borders):
      | left | right | center |

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -68,3 +68,16 @@ Expect (preserve colons to align text):
     | left | right | center |   |
     |:-----|------:|:------:|:--|
     | left | right | center |   |
+
+Given markdown (borderless table);
+   left |right|  center 
+   :- | --: |:---:
+   left |right|  center  
+
+Execute (format borderless table):
+  TableFormat
+
+Expect (table with borders):
+     | left | right | center |
+     |:-----|------:|:------:|
+     | left | right | center |

--- a/test/table-format.vader
+++ b/test/table-format.vader
@@ -75,6 +75,7 @@ Given markdown (borderless table);
    left |right|  center  
 
 Execute (format borderless table):
+  let g:vim_markdown_borderless_table = 1
   TableFormat
 
 Expect (table with borders):


### PR DESCRIPTION
This seems like a valid table(at least in github):
```
header 1|header 2
--|--
data 1|data 2
```

rendered:
header 1|header 2
--|--
data 1|data 2

The solution in this pull request is to wrap all lines that don't have `|` at the beginning or the end.

I also added range call support. It doesn't change the implementation but allows to call `TableFormat` while having the selection.