### PR TITLE
Fix jumping to anchor

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -719,7 +719,7 @@ if !exists('*s:EditUrlUnderCursor')
                 execute l:editmethod l:url
             endif
             if l:anchor !=# ''
-                silent! execute '/'.l:anchor
+                call search(l:anchor, 's')
             endif
         else
             execute l:editmethod . ' <cfile>'


### PR DESCRIPTION
For some reason `execute '/'.l:anchor` does not populate jumplist, so use builtin vim `search()` function