### PR TITLE
Fix documentation for mappings zo/zO and add za/zA

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ The following commands are useful to open and close folds:
 - `zR`: opens all folds
 - `zm`: increases fold level throughout the buffer
 - `zM`: folds everything all the way
-- `za`: open a fold your cursor is on
-- `zA`: open a fold your cursor is on recursively
+- `za`: toggle a fold your cursor is on
+- `zA`: toggle a fold your cursor is on recursively
+- `zo`: open a fold your cursor is on
+- `zO`: open a fold your cursor is on recursively
 - `zc`: close a fold your cursor is on
 - `zC`: close a fold your cursor is on recursively
 

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -102,9 +102,13 @@ The following commands are useful to open and close folds:
                                                               *vim-markdown-zM*
 - 'zM': folds everything all the way
                                                               *vim-markdown-za*
-- 'za': open a fold your cursor is on
+- 'za': toggle a fold your cursor is on
                                                               *vim-markdown-zA*
-- 'zA': open a fold your cursor is on recursively
+- 'zA': toggle a fold your cursor is on recursively
+                                                              *vim-markdown-zo*
+- 'zo': open a fold your cursor is on
+                                                              *vim-markdown-zO*
+- 'zO': open a fold your cursor is on recursively
                                                               *vim-markdown-zc*
 - 'zc': close a fold your cursor is on
                                                               *vim-markdown-zC*


### PR DESCRIPTION
Seems that the mappings for folding commands is still the vim default. This updates the documentations. Fix #632