### PR TITLE
Should contain `code` in headings

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -156,7 +156,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdInlineURL,mkdStrike
+syn cluster mkdHeadingContent contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdLink,mkdInlineURL,mkdStrike,mkdCode
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,mkdStrike
 
 "highlighting for Markdown groups


### PR DESCRIPTION
If you write some C function spec as a `code` block in heading, it may break.

```markdown
# foo `func(int a, int **ppb, int *pc)` bar

foobar
```

![vim_markdown_20240625_123527](https://github.com/preservim/vim-markdown/assets/31273423/7f5c244e-0b12-485b-91f1-4d99981c7ab6)

The part of `**` is considered as a beginning of **bold** style.

Shouldn't you include `mkdCode` in `mkdHeadingContent` to avoid this?
