### PR TITLE
Add match groups for each HTML heading level

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -86,12 +86,12 @@ syn region mkdLinkTitle matchgroup=mkdDelimiter start=+'+     end=+'+  contained
 syn region mkdLinkTitle matchgroup=mkdDelimiter start=+(+     end=+)+  contained
 
 "HTML headings
-syn region htmlH1       matchgroup=mkdHeading     start="^\s*#"                   end="$" contains=@mkdHeadingContent,@Spell
-syn region htmlH2       matchgroup=mkdHeading     start="^\s*##"                  end="$" contains=@mkdHeadingContent,@Spell
-syn region htmlH3       matchgroup=mkdHeading     start="^\s*###"                 end="$" contains=@mkdHeadingContent,@Spell
-syn region htmlH4       matchgroup=mkdHeading     start="^\s*####"                end="$" contains=@mkdHeadingContent,@Spell
-syn region htmlH5       matchgroup=mkdHeading     start="^\s*#####"               end="$" contains=@mkdHeadingContent,@Spell
-syn region htmlH6       matchgroup=mkdHeading     start="^\s*######"              end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH1       matchgroup=mkdHeadingH1     start="^\s*#"                   end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH2       matchgroup=mkdHeadingH2     start="^\s*##"                  end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH3       matchgroup=mkdHeadingH3     start="^\s*###"                 end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH4       matchgroup=mkdHeadingH4     start="^\s*####"                end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH5       matchgroup=mkdHeadingH5     start="^\s*#####"               end="$" contains=@mkdHeadingContent,@Spell
+syn region htmlH6       matchgroup=mkdHeadingH6     start="^\s*######"              end="$" contains=@mkdHeadingContent,@Spell
 syn match  htmlH1       /^.\+\n=\+$/ contains=@mkdHeadingContent,@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@mkdHeadingContent,@Spell
 


### PR DESCRIPTION
The official Dracula Obsidian theme has different coloring for each heading level which looks quite nice.

Individual heading match groups also exist in Vim's default HTML syntax like `markdownH1Delimiter`.

However, vim-markdown cannot do this because it uses the one match group for all heading levels: `mkdHeading`.

So that themes can highlight each heading level separately on groups like `htmlH1`, add a match group for each heading level too.